### PR TITLE
Add 3D card tilt demo

### DIFF
--- a/showcases/01-3d-card-tilt/README.md
+++ b/showcases/01-3d-card-tilt/README.md
@@ -1,0 +1,8 @@
+# 01 — 3D Card Tilt on Cursor
+
+CSS perspective with JavaScript pointer tracking for a subtle 3D tilt.
+Move the pointer across the card to see it tilt toward the cursor.
+
+## Accessibility
+- Resets transform when pointer leaves so it doesn't stay rotated.
+- Honors `prefers-reduced-motion` by disabling the tilt animation.

--- a/showcases/01-3d-card-tilt/index.html
+++ b/showcases/01-3d-card-tilt/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>3D Card Tilt on Cursor</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div class="card-wrapper">
+    <div class="card">
+      <h1>Hover me</h1>
+      <p>3D tilt follows your cursor.</p>
+    </div>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/showcases/01-3d-card-tilt/script.js
+++ b/showcases/01-3d-card-tilt/script.js
@@ -1,0 +1,33 @@
+const wrapper = document.querySelector('.card-wrapper');
+const card = document.querySelector('.card');
+
+function handleMove(e) {
+  const rect = wrapper.getBoundingClientRect();
+  const x = e.clientX - rect.left;
+  const y = e.clientY - rect.top;
+  const midX = rect.width / 2;
+  const midY = rect.height / 2;
+  const rotateY = ((x - midX) / midX) * 15;
+  const rotateX = ((y - midY) / midY) * -15;
+  card.style.transform = `rotateX(${rotateX}deg) rotateY(${rotateY}deg)`;
+}
+
+function reset() {
+  card.style.transform = '';
+}
+
+const motionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+function setup() {
+  if (motionQuery.matches) {
+    wrapper.removeEventListener('pointermove', handleMove);
+    wrapper.removeEventListener('pointerleave', reset);
+    reset();
+    return;
+  }
+  wrapper.addEventListener('pointermove', handleMove);
+  wrapper.addEventListener('pointerleave', reset);
+}
+
+motionQuery.addEventListener('change', setup);
+setup();

--- a/showcases/01-3d-card-tilt/styles.css
+++ b/showcases/01-3d-card-tilt/styles.css
@@ -1,0 +1,39 @@
+* {
+  box-sizing: border-box;
+}
+body {
+  margin: 0;
+  height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #f0f0f0;
+  font-family: system-ui, sans-serif;
+}
+
+.card-wrapper {
+  perspective: 1000px;
+}
+
+.card {
+  width: 300px;
+  height: 400px;
+  border-radius: 20px;
+  background: linear-gradient(135deg, #ff9a9e 0%, #fad0c4 100%);
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.2);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  color: #333;
+  transition: transform 0.1s;
+  will-change: transform;
+}
+
+.card h1 {
+  margin: 0 0 0.5rem;
+}
+
+.card p {
+  margin: 0;
+}


### PR DESCRIPTION
## Summary
- add 3D card tilt showcase with HTML, CSS perspective, and JS pointer tracking
- respect prefers-reduced-motion by disabling tilt when requested

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896a73764948333a9640d5e7828b81c