### PR TITLE
feat: add root index page for showcases

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Animation Effect Showcase</title>
+  <style>
+    body {
+      margin: 0;
+      font-family: system-ui, sans-serif;
+      display: flex;
+      height: 100vh;
+    }
+    nav {
+      width: 250px;
+      background: #f7f7f7;
+      border-right: 1px solid #ccc;
+      overflow-y: auto;
+    }
+    nav ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }
+    nav li {
+      border-bottom: 1px solid #e0e0e0;
+    }
+    nav button {
+      width: 100%;
+      padding: 12px 16px;
+      background: none;
+      border: none;
+      text-align: left;
+      cursor: pointer;
+      font-size: 1rem;
+    }
+    nav button:hover,
+    nav button.active {
+      background: #e0e0e0;
+    }
+    #preview {
+      flex: 1;
+    }
+    #preview iframe {
+      width: 100%;
+      height: 100%;
+      border: none;
+    }
+  </style>
+</head>
+<body>
+  <nav>
+    <ul id="menu"></ul>
+  </nav>
+  <div id="preview">
+    <iframe id="frame" src=""></iframe>
+  </div>
+  <script>
+    const showcases = [
+      { title: '3D Card Tilt', path: 'showcases/01-3d-card-tilt/index.html' }
+    ];
+    const menu = document.getElementById('menu');
+    const frame = document.getElementById('frame');
+    showcases.forEach((s, i) => {
+      const li = document.createElement('li');
+      const btn = document.createElement('button');
+      btn.textContent = `${s.title}`;
+      btn.addEventListener('click', () => {
+        frame.src = s.path;
+        menu.querySelectorAll('button').forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+      });
+      if (i === 0) {
+        btn.classList.add('active');
+        frame.src = s.path;
+      }
+      li.appendChild(btn);
+      menu.appendChild(li);
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add a root `index.html` that lists showcases and previews them side-by-side

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896ba152fe88333bddda14e21d3f050