### PR TITLE
Add glassmorphism cards demo

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,7 +57,8 @@
   </div>
   <script>
     const showcases = [
-      { title: '3D Card Tilt', path: 'showcases/01-3d-card-tilt/index.html' }
+      { title: '3D Card Tilt', path: 'showcases/01-3d-card-tilt/index.html' },
+      { title: 'Glassmorphism Cards', path: 'showcases/02-glassmorphism-cards/index.html' }
     ];
     const menu = document.getElementById('menu');
     const frame = document.getElementById('frame');

--- a/showcases/02-glassmorphism-cards/README.md
+++ b/showcases/02-glassmorphism-cards/README.md
@@ -1,0 +1,7 @@
+# 02 — Glassmorphism Cards
+
+Translucent cards with `backdrop-filter` blur and subtle upward float on hover.
+
+## Accessibility
+- Cards are focusable so keyboard users can trigger the hover animation.
+- Respects `prefers-reduced-motion` by disabling the float transition.

--- a/showcases/02-glassmorphism-cards/index.html
+++ b/showcases/02-glassmorphism-cards/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Glassmorphism Cards</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div class="cards">
+    <div class="card" tabindex="0">
+      <h2>Card One</h2>
+      <p>Frosted glass look.</p>
+    </div>
+    <div class="card" tabindex="0">
+      <h2>Card Two</h2>
+      <p>Hover to float.</p>
+    </div>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/showcases/02-glassmorphism-cards/script.js
+++ b/showcases/02-glassmorphism-cards/script.js
@@ -1,0 +1,1 @@
+// No JavaScript needed for this demo.

--- a/showcases/02-glassmorphism-cards/styles.css
+++ b/showcases/02-glassmorphism-cards/styles.css
@@ -1,0 +1,47 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, #5ee7df 0%, #b490ca 100%);
+  font-family: system-ui, sans-serif;
+}
+
+.cards {
+  display: flex;
+  gap: 2rem;
+}
+
+.card {
+  width: 200px;
+  padding: 1.5rem;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.1);
+  color: #fff;
+  transition: transform 0.3s ease;
+  will-change: transform;
+}
+
+.card:hover,
+.card:focus {
+  transform: translateY(-10px);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .card {
+    transition: none;
+  }
+  .card:hover,
+  .card:focus {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add Glassmorphism Cards showcase featuring blurred backdrop and floating hover effect
- include accessibility: focusable cards and reduced-motion fallback
- link demo from root gallery

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896bbc0bd688333939093ed44110c36