### PR TITLE
Add more CSS and SVG animation showcases

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,7 +59,14 @@
     const showcases = [
       { title: '3D Card Tilt', path: 'showcases/01-3d-card-tilt/index.html' },
       { title: 'Glassmorphism Cards', path: 'showcases/02-glassmorphism-cards/index.html' },
-      { title: 'Neumorphic Toggle', path: 'showcases/03-neumorphic-toggle/index.html' }
+      { title: 'Neumorphic Toggle', path: 'showcases/03-neumorphic-toggle/index.html' },
+      { title: 'Liquid Button Hover', path: 'showcases/04-liquid-button-hover/index.html' },
+      { title: 'Magnetic Buttons', path: 'showcases/05-magnetic-buttons/index.html' },
+      { title: 'Morphing Hamburger Menu', path: 'showcases/06-morphing-hamburger-menu/index.html' },
+      { title: 'Animated Gradient Background', path: 'showcases/07-animated-gradient-background/index.html' },
+      { title: 'Shimmer Skeleton Loader', path: 'showcases/08-shimmer-skeleton-loader/index.html' },
+      { title: 'Text Reveal on Scroll', path: 'showcases/09-text-reveal-on-scroll/index.html' },
+      { title: 'Split Text Line Stagger', path: 'showcases/10-split-text-line-stagger/index.html' }
     ];
     const menu = document.getElementById('menu');
     const frame = document.getElementById('frame');

--- a/showcases/04-liquid-button-hover/README.md
+++ b/showcases/04-liquid-button-hover/README.md
@@ -1,0 +1,7 @@
+# 04 — Liquid Button Hover
+
+Gooey hover effect using SVG filter and CSS clip-path to morph blobs around a button.
+
+## Accessibility
+- Animation respects `prefers-reduced-motion` by pausing blob movement.
+- Button text remains outside the filtered group for clarity.

--- a/showcases/04-liquid-button-hover/index.html
+++ b/showcases/04-liquid-button-hover/index.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Liquid Button Hover</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <button class="liquid-btn">
+    <span class="btn-text">Hover Me</span>
+    <span class="blobs">
+      <span class="blob"></span>
+      <span class="blob"></span>
+      <span class="blob"></span>
+    </span>
+  </button>
+
+  <svg width="0" height="0">
+    <defs>
+      <filter id="goo">
+        <feGaussianBlur in="SourceGraphic" stdDeviation="10" result="blur" />
+        <feColorMatrix in="blur" mode="matrix" values="
+           1 0 0 0 0
+           0 1 0 0 0
+           0 0 1 0 0
+           0 0 0 20 -10" result="goo" />
+        <feBlend in="SourceGraphic" in2="goo" />
+      </filter>
+    </defs>
+  </svg>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/showcases/04-liquid-button-hover/script.js
+++ b/showcases/04-liquid-button-hover/script.js
@@ -1,0 +1,1 @@
+// No JavaScript needed for this demo.

--- a/showcases/04-liquid-button-hover/styles.css
+++ b/showcases/04-liquid-button-hover/styles.css
@@ -1,0 +1,67 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #222;
+  font-family: system-ui, sans-serif;
+}
+
+.liquid-btn {
+  position: relative;
+  padding: 1rem 2.5rem;
+  border: none;
+  background: #ff6b6b;
+  color: #fff;
+  font-size: 1.2rem;
+  border-radius: 40px;
+  cursor: pointer;
+  overflow: hidden;
+}
+
+.btn-text {
+  position: relative;
+  z-index: 1;
+}
+
+.blobs {
+  position: absolute;
+  inset: 0;
+  filter: url(#goo);
+}
+
+.blob {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 120%;
+  height: 120%;
+  background: #ff6b6b;
+  border-radius: 35%;
+  transform: translate(-50%, -50%) scale(0);
+  clip-path: circle(20% at 50% 50%);
+  transition: transform 0.5s ease;
+}
+
+.liquid-btn:hover .blob {
+  transform: translate(-50%, -50%) scale(1);
+}
+
+.liquid-btn:hover .blob:nth-child(2) {
+  transform: translate(-20%, -60%) scale(1.2);
+}
+
+.liquid-btn:hover .blob:nth-child(3) {
+  transform: translate(-80%, -40%) scale(1.1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .blob {
+    transition: none;
+  }
+}

--- a/showcases/05-magnetic-buttons/README.md
+++ b/showcases/05-magnetic-buttons/README.md
@@ -1,0 +1,7 @@
+# 05 — Magnetic Buttons
+
+Buttons are drawn toward the cursor when it gets close, creating a magnetic attraction effect.
+
+## Accessibility
+- Resets translation when cursor leaves the area.
+- Honors `prefers-reduced-motion` by disabling the magnetic motion.

--- a/showcases/05-magnetic-buttons/index.html
+++ b/showcases/05-magnetic-buttons/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Magnetic Buttons</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div class="buttons">
+    <button class="magnet">Button A</button>
+    <button class="magnet">Button B</button>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/showcases/05-magnetic-buttons/script.js
+++ b/showcases/05-magnetic-buttons/script.js
@@ -1,0 +1,32 @@
+const buttons = document.querySelectorAll('.magnet');
+
+function handleMove(e) {
+  buttons.forEach(btn => {
+    const rect = btn.getBoundingClientRect();
+    const x = e.clientX - (rect.left + rect.width / 2);
+    const y = e.clientY - (rect.top + rect.height / 2);
+    const dist = Math.hypot(x, y);
+    if (dist < 150) {
+      btn.style.transform = `translate(${x / 5}px, ${y / 5}px)`;
+    } else {
+      btn.style.transform = '';
+    }
+  });
+}
+
+function reset() {
+  buttons.forEach(btn => (btn.style.transform = ''));
+}
+
+const motionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+function setup() {
+  reset();
+  window.removeEventListener('pointermove', handleMove);
+  if (!motionQuery.matches) {
+    window.addEventListener('pointermove', handleMove);
+  }
+}
+
+motionQuery.addEventListener('change', setup);
+setup();

--- a/showcases/05-magnetic-buttons/styles.css
+++ b/showcases/05-magnetic-buttons/styles.css
@@ -1,0 +1,35 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #fafafa;
+  font-family: system-ui, sans-serif;
+}
+
+.buttons {
+  display: flex;
+  gap: 2rem;
+}
+
+.magnet {
+  padding: 1rem 2rem;
+  background: #6200ea;
+  color: #fff;
+  border: none;
+  border-radius: 30px;
+  cursor: pointer;
+  transition: transform 0.2s;
+  will-change: transform;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .magnet {
+    transition: none;
+  }
+}

--- a/showcases/06-morphing-hamburger-menu/README.md
+++ b/showcases/06-morphing-hamburger-menu/README.md
@@ -1,0 +1,7 @@
+# 06 — Morphing Hamburger Menu
+
+SVG path morph to transition a three-line menu into a close icon with smooth CSS transitions.
+
+## Accessibility
+- Transition disabled when `prefers-reduced-motion` is set.
+- Button has descriptive label and uses `aria-expanded` for state.

--- a/showcases/06-morphing-hamburger-menu/index.html
+++ b/showcases/06-morphing-hamburger-menu/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>Morphing Hamburger Menu</title>
+<link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+<button id="burger" aria-label="Menu" aria-expanded="false">
+  <svg viewBox="0 0 100 80" width="60" height="60">
+    <path id="line1" d="M20 30 H80" />
+    <path id="line2" d="M20 50 H80" />
+    <path id="line3" d="M20 70 H80" />
+  </svg>
+</button>
+<script src="script.js"></script>
+</body>
+</html>

--- a/showcases/06-morphing-hamburger-menu/script.js
+++ b/showcases/06-morphing-hamburger-menu/script.js
@@ -1,0 +1,6 @@
+const btn = document.getElementById('burger');
+
+btn.addEventListener('click', () => {
+  const open = btn.classList.toggle('open');
+  btn.setAttribute('aria-expanded', open);
+});

--- a/showcases/06-morphing-hamburger-menu/styles.css
+++ b/showcases/06-morphing-hamburger-menu/styles.css
@@ -1,0 +1,35 @@
+body {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+  margin: 0;
+  background: #f0f0f0;
+}
+button {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+}
+svg path {
+  fill: none;
+  stroke: #333;
+  stroke-width: 10;
+  stroke-linecap: round;
+  transition: d 0.3s ease, opacity 0.3s ease;
+}
+button.open #line1 {
+  d: path("M30 30 L70 70");
+}
+button.open #line2 {
+  d: path("M30 70 L70 30");
+}
+button.open #line3 {
+  opacity: 0;
+}
+@media (prefers-reduced-motion: reduce) {
+  svg path {
+    transition: none;
+  }
+}

--- a/showcases/07-animated-gradient-background/README.md
+++ b/showcases/07-animated-gradient-background/README.md
@@ -1,0 +1,6 @@
+# 07 — Animated Gradient Background
+
+Looping background gradient built with CSS custom properties and keyframe animation.
+
+## Accessibility
+- Gradient animation stops when `prefers-reduced-motion` is enabled.

--- a/showcases/07-animated-gradient-background/index.html
+++ b/showcases/07-animated-gradient-background/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>Animated Gradient Background</title>
+<link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+<h1>Vibrant Background</h1>
+<script src="script.js"></script>
+</body>
+</html>

--- a/showcases/07-animated-gradient-background/script.js
+++ b/showcases/07-animated-gradient-background/script.js
@@ -1,0 +1,1 @@
+// No JavaScript needed for this demo.

--- a/showcases/07-animated-gradient-background/styles.css
+++ b/showcases/07-animated-gradient-background/styles.css
@@ -1,0 +1,27 @@
+:root {
+  --hue: 0;
+}
+body {
+  margin: 0;
+  height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: white;
+  font-family: system-ui, sans-serif;
+  background: linear-gradient(45deg,
+    hsl(var(--hue) 70% 55%),
+    hsl(calc(var(--hue) + 60) 70% 55%)
+  );
+  animation: shift 8s linear infinite;
+}
+@keyframes shift {
+  to {
+    --hue: 360;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  body {
+    animation: none;
+  }
+}

--- a/showcases/08-shimmer-skeleton-loader/README.md
+++ b/showcases/08-shimmer-skeleton-loader/README.md
@@ -1,0 +1,6 @@
+# 08 — Shimmer Skeleton Loader
+
+Placeholder cards with a shimmering gradient to mimic loading content.
+
+## Accessibility
+- Shimmer animation respects `prefers-reduced-motion` by staying static.

--- a/showcases/08-shimmer-skeleton-loader/index.html
+++ b/showcases/08-shimmer-skeleton-loader/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>Shimmer Skeleton Loader</title>
+<link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+<div class="card">
+  <div class="avatar skeleton"></div>
+  <div class="line skeleton w-80"></div>
+  <div class="line skeleton w-60"></div>
+</div>
+<script src="script.js"></script>
+</body>
+</html>

--- a/showcases/08-shimmer-skeleton-loader/script.js
+++ b/showcases/08-shimmer-skeleton-loader/script.js
@@ -1,0 +1,1 @@
+// No JavaScript needed for this demo.

--- a/showcases/08-shimmer-skeleton-loader/styles.css
+++ b/showcases/08-shimmer-skeleton-loader/styles.css
@@ -1,0 +1,52 @@
+body {
+  margin: 0;
+  height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #fafafa;
+  font-family: system-ui, sans-serif;
+}
+.card {
+  width: 200px;
+}
+.skeleton {
+  background: #ddd;
+  border-radius: 4px;
+  position: relative;
+  overflow: hidden;
+}
+.avatar {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  margin-bottom: 16px;
+}
+.line {
+  height: 12px;
+  margin-bottom: 8px;
+}
+.w-80 {
+  width: 80%;
+}
+.w-60 {
+  width: 60%;
+}
+.skeleton::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  transform: translateX(-100%);
+  background: linear-gradient(90deg, transparent, rgba(255,255,255,0.6), transparent);
+  animation: shimmer 1.5s infinite;
+}
+@keyframes shimmer {
+  to {
+    transform: translateX(100%);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .skeleton::after {
+    animation: none;
+  }
+}

--- a/showcases/09-text-reveal-on-scroll/README.md
+++ b/showcases/09-text-reveal-on-scroll/README.md
@@ -1,0 +1,7 @@
+# 09 — Text Reveal on Scroll
+
+Text blocks reveal with a sliding clip-path as they enter the viewport using Intersection Observer.
+
+## Accessibility
+- Elements reveal instantly when `prefers-reduced-motion` is detected.
+- Observer unobserves after revealing to avoid unnecessary work.

--- a/showcases/09-text-reveal-on-scroll/index.html
+++ b/showcases/09-text-reveal-on-scroll/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>Text Reveal on Scroll</title>
+<link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+<section class="reveal">First section of text to reveal.</section>
+<section class="reveal">Another section comes into view.</section>
+<section class="reveal">Final bit of text revealed on scroll.</section>
+<script src="script.js"></script>
+</body>
+</html>

--- a/showcases/09-text-reveal-on-scroll/script.js
+++ b/showcases/09-text-reveal-on-scroll/script.js
@@ -1,0 +1,16 @@
+const blocks = document.querySelectorAll('.reveal');
+const motion = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+if (motion.matches) {
+  blocks.forEach(b => b.classList.add('visible'));
+} else {
+  const io = new IntersectionObserver(entries => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        entry.target.classList.add('visible');
+        io.unobserve(entry.target);
+      }
+    });
+  }, { threshold: 0.2 });
+  blocks.forEach(b => io.observe(b));
+}

--- a/showcases/09-text-reveal-on-scroll/styles.css
+++ b/showcases/09-text-reveal-on-scroll/styles.css
@@ -1,0 +1,24 @@
+body {
+  margin: 0;
+  font-family: system-ui, sans-serif;
+}
+section {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2rem;
+}
+.reveal {
+  clip-path: inset(0 100% 0 0);
+  transition: clip-path 0.6s ease-out;
+}
+.reveal.visible {
+  clip-path: inset(0 0 0 0);
+}
+@media (prefers-reduced-motion: reduce) {
+  .reveal {
+    clip-path: none;
+    transition: none;
+  }
+}

--- a/showcases/10-split-text-line-stagger/README.md
+++ b/showcases/10-split-text-line-stagger/README.md
@@ -1,0 +1,7 @@
+# 10 — Split Text Line Stagger
+
+Utility script splits text into spans with CSS variables for staggered entrance.
+
+## Accessibility
+- Original text retained via `aria-label` so screen readers announce it once.
+- Staggered motion disabled when `prefers-reduced-motion` is enabled.

--- a/showcases/10-split-text-line-stagger/index.html
+++ b/showcases/10-split-text-line-stagger/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>Split Text Line Stagger</title>
+<link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+<h1 class="stagger" aria-label="Split Text Line Stagger">Split Text Line Stagger</h1>
+<script src="script.js"></script>
+</body>
+</html>

--- a/showcases/10-split-text-line-stagger/script.js
+++ b/showcases/10-split-text-line-stagger/script.js
@@ -1,0 +1,19 @@
+const target = document.querySelector('.stagger');
+const text = target.textContent.trim();
+target.setAttribute('aria-label', text);
+target.textContent = '';
+
+text.split('').forEach((ch, i) => {
+  const span = document.createElement('span');
+  span.textContent = ch === ' ' ? '\u00A0' : ch;
+  span.style.setProperty('--i', i);
+  target.appendChild(span);
+});
+
+const motion = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+if (motion.matches) {
+  target.classList.add('ready');
+} else {
+  requestAnimationFrame(() => target.classList.add('ready'));
+}

--- a/showcases/10-split-text-line-stagger/styles.css
+++ b/showcases/10-split-text-line-stagger/styles.css
@@ -1,0 +1,24 @@
+body {
+  height: 100vh;
+  margin: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: system-ui, sans-serif;
+  background: #f0f0f0;
+}
+.stagger span {
+  display: inline-block;
+  transform: translateY(100%);
+  transition: transform 0.5s ease;
+  transition-delay: calc(var(--i) * 50ms);
+}
+.stagger.ready span {
+  transform: translateY(0);
+}
+@media (prefers-reduced-motion: reduce) {
+  .stagger span {
+    transition: none;
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add morphing hamburger menu demo with SVG path transitions
- include animated gradient background and shimmering skeleton loader
- introduce text reveal on scroll and split text stagger effects
- register all new demos in gallery index

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896c35bf34c83338f62c2f6b75d191f