### PR TITLE
Add showcases 16-20

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,7 +71,12 @@
       { title: 'Sticky Section Transitions', path: 'showcases/12-sticky-section-transitions/index.html' },
       { title: 'Curtain Page Reveal', path: 'showcases/13-curtain-page-reveal/index.html' },
       { title: 'Card Stack Swipe', path: 'showcases/14-card-stack-swipe/index.html' },
-      { title: 'Elastic Tabs', path: 'showcases/15-elastic-tabs/index.html' }
+      { title: 'Elastic Tabs', path: 'showcases/15-elastic-tabs/index.html' },
+      { title: 'FAB Fan Menu', path: 'showcases/16-fab-radial-menu/index.html' },
+      { title: 'Breadcrumb Progress Bar', path: 'showcases/17-breadcrumb-progress-bar/index.html' },
+      { title: 'Confetti Button Success', path: 'showcases/18-confetti-button-success/index.html' },
+      { title: 'Toast Notification Queue', path: 'showcases/19-toast-notification-queue/index.html' },
+      { title: 'Pull to Refresh', path: 'showcases/20-pull-to-refresh/index.html' }
     ];
     const menu = document.getElementById('menu');
     const frame = document.getElementById('frame');

--- a/showcases/16-fab-radial-menu/README.md
+++ b/showcases/16-fab-radial-menu/README.md
@@ -1,0 +1,6 @@
+# 16 — Floating Action Button (FAB) Fan
+Radial menu expansion from a floating action button.
+Click the button to fan out secondary actions.
+## Accessibility
+- Main button toggles `aria-expanded` to reflect state.
+- Respects `prefers-reduced-motion` by removing transitions.

--- a/showcases/16-fab-radial-menu/index.html
+++ b/showcases/16-fab-radial-menu/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Floating Action Button Fan</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div class="fab" aria-label="Menu">
+    <button class="fab-main" aria-expanded="false">+</button>
+    <ul class="fab-menu">
+      <li><button aria-label="Action 1">1</button></li>
+      <li><button aria-label="Action 2">2</button></li>
+      <li><button aria-label="Action 3">3</button></li>
+    </ul>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/showcases/16-fab-radial-menu/script.js
+++ b/showcases/16-fab-radial-menu/script.js
@@ -1,0 +1,14 @@
+const fab = document.querySelector('.fab');
+const mainBtn = document.querySelector('.fab-main');
+
+mainBtn.addEventListener('click', () => {
+  const open = fab.classList.toggle('open');
+  mainBtn.setAttribute('aria-expanded', open);
+});
+
+document.addEventListener('click', (e) => {
+  if (!fab.contains(e.target)) {
+    fab.classList.remove('open');
+    mainBtn.setAttribute('aria-expanded', 'false');
+  }
+});

--- a/showcases/16-fab-radial-menu/styles.css
+++ b/showcases/16-fab-radial-menu/styles.css
@@ -1,0 +1,68 @@
+* {
+  box-sizing: border-box;
+}
+body {
+  margin: 0;
+  height: 100vh;
+  font-family: system-ui, sans-serif;
+  background: #f0f0f0;
+}
+.fab {
+  position: fixed;
+  bottom: 40px;
+  right: 40px;
+}
+.fab-main {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  border: none;
+  background: #6200ee;
+  color: #fff;
+  font-size: 2rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.2);
+}
+.fab-menu {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  position: absolute;
+  bottom: 0;
+  right: 0;
+}
+.fab-menu li {
+  position: absolute;
+  transform: translate(0,0) scale(0);
+  transition: transform 0.3s;
+}
+.fab-menu button {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: none;
+  background: #03dac5;
+  color: #000;
+  cursor: pointer;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+}
+.fab.open .fab-menu li {
+  transform: scale(1);
+}
+.fab.open .fab-menu li:nth-child(1) {
+  transform: translate(0,-80px) scale(1);
+}
+.fab.open .fab-menu li:nth-child(2) {
+  transform: translate(-56px,-56px) scale(1);
+}
+.fab.open .fab-menu li:nth-child(3) {
+  transform: translate(-80px,0) scale(1);
+}
+@media (prefers-reduced-motion: reduce) {
+  .fab-menu li {
+    transition: none;
+  }
+}

--- a/showcases/17-breadcrumb-progress-bar/README.md
+++ b/showcases/17-breadcrumb-progress-bar/README.md
@@ -1,0 +1,6 @@
+# 17 — Breadcrumb Progress Bar
+Animated step transitions for multi-step processes.
+Click Next to advance through the steps.
+## Accessibility
+- Announces current step via an `aria-live` region.
+- Respects `prefers-reduced-motion` to disable animations.

--- a/showcases/17-breadcrumb-progress-bar/index.html
+++ b/showcases/17-breadcrumb-progress-bar/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Breadcrumb Progress Bar</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <ul class="progress" role="list">
+    <li class="active" role="listitem">Step 1</li>
+    <li role="listitem">Step 2</li>
+    <li role="listitem">Step 3</li>
+    <li role="listitem">Step 4</li>
+  </ul>
+  <button id="next">Next</button>
+  <div id="status" class="visually-hidden" aria-live="polite"></div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/showcases/17-breadcrumb-progress-bar/script.js
+++ b/showcases/17-breadcrumb-progress-bar/script.js
@@ -1,0 +1,20 @@
+const steps = document.querySelectorAll('.progress li');
+const nextBtn = document.getElementById('next');
+const status = document.getElementById('status');
+let current = 0;
+
+function announce() {
+  status.textContent = `Step ${current + 1} of ${steps.length}`;
+}
+
+nextBtn.addEventListener('click', () => {
+  if (current < steps.length - 1) {
+    steps[current].classList.remove('active');
+    steps[current].classList.add('complete');
+    current++;
+    steps[current].classList.add('active');
+    announce();
+  }
+});
+
+announce();

--- a/showcases/17-breadcrumb-progress-bar/styles.css
+++ b/showcases/17-breadcrumb-progress-bar/styles.css
@@ -1,0 +1,77 @@
+* {
+  box-sizing: border-box;
+}
+body {
+  margin: 0;
+  font-family: system-ui, sans-serif;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+  background: #fafafa;
+}
+.progress {
+  display: flex;
+  list-style: none;
+  padding: 0;
+  margin: 0 0 20px;
+  width: 80%;
+  max-width: 400px;
+}
+.progress li {
+  flex: 1;
+  position: relative;
+  text-align: center;
+  padding: 10px 0;
+  background: #e0e0e0;
+  color: #666;
+  transition: background 0.3s, color 0.3s;
+}
+.progress li.active,
+.progress li.complete {
+  background: #6200ee;
+  color: #fff;
+}
+.progress li::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 100%;
+  width: 0;
+  height: 4px;
+  background: #6200ee;
+  transform: translateY(-50%);
+  transition: width 0.3s;
+}
+.progress li.complete::after {
+  width: 100%;
+}
+.progress li:last-child::after {
+  display: none;
+}
+button {
+  padding: 8px 16px;
+  border: none;
+  background: #6200ee;
+  color: #fff;
+  cursor: pointer;
+  border-radius: 4px;
+}
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+@media (prefers-reduced-motion: reduce) {
+  .progress li,
+  .progress li::after {
+    transition: none;
+  }
+}

--- a/showcases/18-confetti-button-success/README.md
+++ b/showcases/18-confetti-button-success/README.md
@@ -1,0 +1,5 @@
+# 18 — Confetti Button Success
+Click the button to launch a burst of confetti drawn with canvas.
+## Accessibility
+- Disabled when `prefers-reduced-motion` is set.
+- Canvas is `pointer-events: none` so it doesn't block interaction.

--- a/showcases/18-confetti-button-success/index.html
+++ b/showcases/18-confetti-button-success/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Confetti Button Success</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <button id="go">Celebrate</button>
+  <canvas id="confetti"></canvas>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/showcases/18-confetti-button-success/script.js
+++ b/showcases/18-confetti-button-success/script.js
@@ -1,0 +1,46 @@
+const btn = document.getElementById('go');
+const canvas = document.getElementById('confetti');
+const ctx = canvas.getContext('2d');
+let particles = [];
+
+function resize() {
+  canvas.width = innerWidth;
+  canvas.height = innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+function createConfetti(x, y) {
+  for (let i = 0; i < 100; i++) {
+    particles.push({
+      x,
+      y,
+      vx: (Math.random() - 0.5) * 6,
+      vy: Math.random() * -3 - 2,
+      color: `hsl(${Math.random() * 360}, 100%, 50%)`,
+      size: Math.random() * 6 + 2,
+      life: 100
+    });
+  }
+}
+
+function update() {
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  particles.forEach(p => {
+    p.x += p.vx;
+    p.y += p.vy;
+    p.vy += 0.05;
+    p.life--;
+    ctx.fillStyle = p.color;
+    ctx.fillRect(p.x, p.y, p.size, p.size);
+  });
+  particles = particles.filter(p => p.life > 0);
+  requestAnimationFrame(update);
+}
+update();
+
+btn.addEventListener('click', e => {
+  if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+  const rect = e.target.getBoundingClientRect();
+  createConfetti(rect.left + rect.width / 2, rect.top + rect.height / 2);
+});

--- a/showcases/18-confetti-button-success/styles.css
+++ b/showcases/18-confetti-button-success/styles.css
@@ -1,0 +1,32 @@
+* {
+  box-sizing: border-box;
+}
+body {
+  margin: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+  background: #fdfdfd;
+  font-family: system-ui, sans-serif;
+}
+button {
+  padding: 12px 20px;
+  font-size: 1rem;
+  border: none;
+  border-radius: 4px;
+  background: #6200ee;
+  color: #fff;
+  cursor: pointer;
+}
+#confetti {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+@media (prefers-reduced-motion: reduce) {
+  #confetti { display: none; }
+}

--- a/showcases/19-toast-notification-queue/README.md
+++ b/showcases/19-toast-notification-queue/README.md
@@ -1,0 +1,6 @@
+# 19 — Toast Notification In/Out
+Slide and fade toast messages with a simple queue.
+Click the button multiple times to queue notifications.
+## Accessibility
+- Container uses `aria-live` to announce messages.
+- Respects `prefers-reduced-motion` to disable transitions.

--- a/showcases/19-toast-notification-queue/index.html
+++ b/showcases/19-toast-notification-queue/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Toast Notification Queue</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <button id="show">Show Toast</button>
+  <div id="toasts" class="toast-container" aria-live="polite"></div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/showcases/19-toast-notification-queue/script.js
+++ b/showcases/19-toast-notification-queue/script.js
@@ -1,0 +1,31 @@
+const container = document.getElementById('toasts');
+const btn = document.getElementById('show');
+let queue = [];
+let showing = false;
+let count = 0;
+
+btn.addEventListener('click', () => {
+  queue.push(`Toast ${++count}`);
+  if (!showing) showNext();
+});
+
+function showNext() {
+  if (queue.length === 0) {
+    showing = false;
+    return;
+  }
+  showing = true;
+  const msg = queue.shift();
+  const toast = document.createElement('div');
+  toast.className = 'toast';
+  toast.textContent = msg;
+  container.appendChild(toast);
+  requestAnimationFrame(() => toast.classList.add('show'));
+  setTimeout(() => {
+    toast.classList.remove('show');
+    setTimeout(() => {
+      container.removeChild(toast);
+      showNext();
+    }, 300);
+  }, 3000);
+}

--- a/showcases/19-toast-notification-queue/styles.css
+++ b/showcases/19-toast-notification-queue/styles.css
@@ -1,0 +1,46 @@
+* {
+  box-sizing: border-box;
+}
+body {
+  margin: 0;
+  font-family: system-ui, sans-serif;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+  background: #f5f5f5;
+}
+button {
+  padding: 10px 20px;
+  border: none;
+  border-radius: 4px;
+  background: #6200ee;
+  color: #fff;
+  cursor: pointer;
+}
+.toast-container {
+  position: fixed;
+  top: 20px;
+  right: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.toast {
+  background: #333;
+  color: #fff;
+  padding: 10px 16px;
+  border-radius: 4px;
+  transform: translateX(100%);
+  opacity: 0;
+  transition: transform 0.3s, opacity 0.3s;
+}
+.toast.show {
+  transform: translateX(0);
+  opacity: 1;
+}
+@media (prefers-reduced-motion: reduce) {
+  .toast {
+    transition: none;
+  }
+}

--- a/showcases/20-pull-to-refresh/README.md
+++ b/showcases/20-pull-to-refresh/README.md
@@ -1,0 +1,5 @@
+# 20 — Pull to Refresh (Web)
+Drag from the top to reveal an indicator and trigger a fake refresh.
+## Accessibility
+- Uses pointer events for mouse and touch.
+- Respects `prefers-reduced-motion` to avoid animated transitions.

--- a/showcases/20-pull-to-refresh/index.html
+++ b/showcases/20-pull-to-refresh/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Pull to Refresh</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div id="pull"><span id="pullText">↓ Pull to refresh</span></div>
+  <div id="content">
+    <p>Scroll me...</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque habitant morbi tristique senectus et netus.</p>
+    <p>More content here to enable scrolling.</p>
+    <p>Even more filler text to make the page taller.</p>
+    <p>Keep scrolling...</p>
+    <p>End of content.</p>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/showcases/20-pull-to-refresh/script.js
+++ b/showcases/20-pull-to-refresh/script.js
@@ -1,0 +1,58 @@
+const pull = document.getElementById('pull');
+const pullText = document.getElementById('pullText');
+let startY = null;
+let currentY = 0;
+const threshold = 80;
+let refreshing = false;
+
+window.addEventListener('pointerdown', e => {
+  if (window.scrollY === 0 && !refreshing) {
+    startY = e.clientY;
+  }
+});
+
+window.addEventListener('pointermove', e => {
+  if (startY !== null && !refreshing) {
+    currentY = e.clientY - startY;
+    if (currentY > 0) {
+      e.preventDefault();
+      const translate = Math.min(currentY, threshold + 40) - 50;
+      pull.style.transform = `translateY(${translate}px)`;
+    }
+  }
+}, { passive: false });
+
+window.addEventListener('pointerup', () => {
+  if (startY !== null && !refreshing) {
+    if (currentY > threshold) {
+      doRefresh();
+    } else {
+      reset();
+    }
+  }
+  startY = null;
+  currentY = 0;
+});
+
+function reset() {
+  pull.style.transition = 'transform 0.3s';
+  pull.style.transform = 'translateY(-100%)';
+  pull.addEventListener('transitionend', () => {
+    pull.style.transition = '';
+  }, { once: true });
+}
+
+function doRefresh() {
+  refreshing = true;
+  pullText.textContent = 'Refreshing...';
+  pull.style.transition = 'transform 0.3s';
+  pull.style.transform = 'translateY(0)';
+  setTimeout(() => {
+    pullText.textContent = 'Done';
+    setTimeout(() => {
+      reset();
+      pullText.textContent = '↓ Pull to refresh';
+      refreshing = false;
+    }, 500);
+  }, 800);
+}

--- a/showcases/20-pull-to-refresh/styles.css
+++ b/showcases/20-pull-to-refresh/styles.css
@@ -1,0 +1,29 @@
+* {
+  box-sizing: border-box;
+}
+body {
+  margin: 0;
+  font-family: system-ui, sans-serif;
+}
+#pull {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 50px;
+  background: #6200ee;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transform: translateY(-100%);
+}
+#content {
+  padding: 60px 20px 20px;
+  line-height: 1.6;
+}
+@media (prefers-reduced-motion: reduce) {
+  #pull {
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## Summary
- Add FAB fan radial menu demo
- Add breadcrumb progress bar with step transitions
- Add canvas confetti button success effect
- Add toast notification queue with slide in/out
- Add pull-to-refresh interaction for web pages
- Update gallery index with new showcases

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896d81433208333aca40a5744ea18a6