### PR TITLE
Add showcase demos 21-30

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,7 +76,17 @@
       { title: 'Breadcrumb Progress Bar', path: 'showcases/17-breadcrumb-progress-bar/index.html' },
       { title: 'Confetti Button Success', path: 'showcases/18-confetti-button-success/index.html' },
       { title: 'Toast Notification Queue', path: 'showcases/19-toast-notification-queue/index.html' },
-      { title: 'Pull to Refresh', path: 'showcases/20-pull-to-refresh/index.html' }
+      { title: 'Pull to Refresh', path: 'showcases/20-pull-to-refresh/index.html' },
+      { title: 'Circular Progress with Tick', path: 'showcases/21-circular-progress-tick/index.html' },
+      { title: 'Interactive Rating Stars', path: 'showcases/22-interactive-rating-stars/index.html' },
+      { title: 'Accordion with Smooth Height', path: 'showcases/23-accordion-smooth-height/index.html' },
+      { title: 'Tabs with Ink Ripple', path: 'showcases/24-tabs-ink-ripple/index.html' },
+      { title: 'Input Focus Glow', path: 'showcases/25-input-focus-glow/index.html' },
+      { title: 'Password Strength Meter', path: 'showcases/26-password-strength-meter/index.html' },
+      { title: 'Search Autocomplete Pop', path: 'showcases/27-search-autocomplete-pop/index.html' },
+      { title: 'Animated Placeholder Labels', path: 'showcases/28-animated-placeholder-labels/index.html' },
+      { title: 'Stepper Form with Slide', path: 'showcases/29-stepper-form-slide/index.html' },
+      { title: 'Drag & Drop Sortable List', path: 'showcases/30-drag-drop-sortable-list/index.html' }
     ];
     const menu = document.getElementById('menu');
     const frame = document.getElementById('frame');

--- a/showcases/21-circular-progress-tick/README.md
+++ b/showcases/21-circular-progress-tick/README.md
@@ -1,0 +1,4 @@
+# 21 — Circular Progress with Tick
+SVG circle stroke animates to fill, morphs into a check mark.
+## Accessibility
+- Respects `prefers-reduced-motion` by disabling animation.

--- a/showcases/21-circular-progress-tick/index.html
+++ b/showcases/21-circular-progress-tick/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Circular Progress with Tick</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <button id="start" aria-label="start progress">Start</button>
+  <svg class="progress" viewBox="0 0 100 100" aria-hidden="true">
+    <circle cx="50" cy="50" r="45" />
+    <path id="check" d="M30 50 L45 65 L70 40" />
+  </svg>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/showcases/21-circular-progress-tick/script.js
+++ b/showcases/21-circular-progress-tick/script.js
@@ -1,0 +1,20 @@
+const circle = document.querySelector('circle');
+const svg = document.querySelector('.progress');
+const btn = document.getElementById('start');
+const radius = circle.r.baseVal.value;
+const circumference = 2 * Math.PI * radius;
+circle.style.strokeDasharray = `${circumference}`;
+circle.style.strokeDashoffset = circumference;
+
+btn.addEventListener('click', () => {
+  circle.style.strokeDashoffset = '0';
+});
+
+circle.addEventListener('transitionend', () => {
+  svg.classList.add('done');
+});
+
+const motion = window.matchMedia('(prefers-reduced-motion: reduce)');
+if (motion.matches) {
+  circle.style.transition = 'none';
+}

--- a/showcases/21-circular-progress-tick/styles.css
+++ b/showcases/21-circular-progress-tick/styles.css
@@ -1,0 +1,39 @@
+body {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  gap: 1rem;
+  font-family: sans-serif;
+}
+.progress {
+  width: 120px;
+  height: 120px;
+  transform: rotate(-90deg);
+}
+.progress circle {
+  fill: none;
+  stroke: #4caf50;
+  stroke-width: 10;
+  stroke-linecap: round;
+  transition: stroke-dashoffset 1s linear;
+}
+#check {
+  fill: none;
+  stroke: #4caf50;
+  stroke-width: 10;
+  stroke-linecap: round;
+  stroke-dasharray: 100;
+  stroke-dashoffset: 100;
+}
+.progress.done #check {
+  transition: stroke-dashoffset .3s ease;
+  stroke-dashoffset: 0;
+}
+@media (prefers-reduced-motion: reduce) {
+  .progress circle,
+  .progress.done #check {
+    transition: none;
+  }
+}

--- a/showcases/22-interactive-rating-stars/README.md
+++ b/showcases/22-interactive-rating-stars/README.md
@@ -1,0 +1,5 @@
+# 22 — Interactive Rating Stars
+Hover fills stars with a wave, click to set rating.
+## Accessibility
+- Buttons are focusable and operable via keyboard.
+- Respects `prefers-reduced-motion` to remove wave delays.

--- a/showcases/22-interactive-rating-stars/index.html
+++ b/showcases/22-interactive-rating-stars/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Interactive Rating Stars</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div class="rating" role="radiogroup">
+    <button class="star" aria-label="1 star" data-value="1">★</button>
+    <button class="star" aria-label="2 stars" data-value="2">★</button>
+    <button class="star" aria-label="3 stars" data-value="3">★</button>
+    <button class="star" aria-label="4 stars" data-value="4">★</button>
+    <button class="star" aria-label="5 stars" data-value="5">★</button>
+  </div>
+  <p id="out" aria-live="polite"></p>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/showcases/22-interactive-rating-stars/script.js
+++ b/showcases/22-interactive-rating-stars/script.js
@@ -1,0 +1,21 @@
+const stars = document.querySelectorAll('.star');
+const rating = document.querySelector('.rating');
+const out = document.getElementById('out');
+stars.forEach((star, i) => {
+  star.style.setProperty('--i', i);
+  star.addEventListener('mouseenter', () => {
+    stars.forEach((s, j) => {
+      s.classList.toggle('hover', j <= i);
+    });
+  });
+  star.addEventListener('click', () => {
+    stars.forEach((s, j) => s.classList.toggle('selected', j <= i));
+    out.textContent = `Rating: ${i + 1}`;
+  });
+});
+rating.addEventListener('mouseleave', () => {
+  stars.forEach(s => s.classList.remove('hover'));
+});
+
+const motion = window.matchMedia('(prefers-reduced-motion: reduce)');
+if (motion.matches) rating.dataset.motion = 'no';

--- a/showcases/22-interactive-rating-stars/styles.css
+++ b/showcases/22-interactive-rating-stars/styles.css
@@ -1,0 +1,29 @@
+body {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+  font-family: sans-serif;
+}
+.rating {
+  display: flex;
+}
+.star {
+  font-size: 2.5rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: #ccc;
+  transition: color .2s ease;
+}
+.star.hover,
+.star.selected {
+  color: gold;
+}
+.star.hover {
+  transition-delay: calc(var(--i) * 60ms);
+}
+.rating[data-motion="no"] .star.hover {
+  transition-delay: 0ms;
+}

--- a/showcases/23-accordion-smooth-height/README.md
+++ b/showcases/23-accordion-smooth-height/README.md
@@ -1,0 +1,5 @@
+# 23 — Accordion with Smooth Height
+Expanding panels animate to their content height without jank.
+## Accessibility
+- Uses buttons with ARIA attributes for state.
+- Respects `prefers-reduced-motion` to remove height transition.

--- a/showcases/23-accordion-smooth-height/index.html
+++ b/showcases/23-accordion-smooth-height/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Accordion with Smooth Height</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div class="accordion">
+    <div class="item">
+      <button aria-expanded="false">Section 1</button>
+      <div class="panel">Lorem ipsum dolor sit amet.</div>
+    </div>
+    <div class="item">
+      <button aria-expanded="false">Section 2</button>
+      <div class="panel">More content here.</div>
+    </div>
+    <div class="item">
+      <button aria-expanded="false">Section 3</button>
+      <div class="panel">Last bit of text.</div>
+    </div>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/showcases/23-accordion-smooth-height/script.js
+++ b/showcases/23-accordion-smooth-height/script.js
@@ -1,0 +1,14 @@
+const items = document.querySelectorAll('.item');
+const motion = window.matchMedia('(prefers-reduced-motion: reduce)');
+items.forEach(item => {
+  const btn = item.querySelector('button');
+  const panel = item.querySelector('.panel');
+  btn.addEventListener('click', () => {
+    const open = item.classList.toggle('open');
+    btn.setAttribute('aria-expanded', open);
+    panel.style.maxHeight = open ? panel.scrollHeight + 'px' : 0;
+    if (motion.matches) {
+      panel.style.transition = 'none';
+    }
+  });
+});

--- a/showcases/23-accordion-smooth-height/styles.css
+++ b/showcases/23-accordion-smooth-height/styles.css
@@ -1,0 +1,33 @@
+body {
+  font-family: sans-serif;
+  display: flex;
+  justify-content: center;
+  padding-top: 2rem;
+}
+.accordion {
+  width: 300px;
+}
+.item button {
+  width: 100%;
+  text-align: left;
+  padding: 1rem;
+  background: #eee;
+  border: none;
+  cursor: pointer;
+  font-size: 1rem;
+}
+.panel {
+  overflow: hidden;
+  max-height: 0;
+  background: #fafafa;
+  padding: 0 1rem;
+  transition: max-height .3s ease;
+}
+.item.open .panel {
+  padding: 1rem;
+}
+@media (prefers-reduced-motion: reduce) {
+  .panel {
+    transition: none;
+  }
+}

--- a/showcases/24-tabs-ink-ripple/README.md
+++ b/showcases/24-tabs-ink-ripple/README.md
@@ -1,0 +1,5 @@
+# 24 — Tabs with Ink Ripple
+Clicking a tab shows a material-like ripple using pseudo-elements.
+## Accessibility
+- Tabs are buttons with appropriate roles.
+- Respects `prefers-reduced-motion` by skipping ripple animation.

--- a/showcases/24-tabs-ink-ripple/index.html
+++ b/showcases/24-tabs-ink-ripple/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Tabs with Ink Ripple</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div class="tabs" role="tablist">
+    <button role="tab" aria-selected="true" data-target="one">One</button>
+    <button role="tab" aria-selected="false" data-target="two">Two</button>
+    <button role="tab" aria-selected="false" data-target="three">Three</button>
+  </div>
+  <div class="panels">
+    <div id="one" class="panel active">First panel</div>
+    <div id="two" class="panel">Second panel</div>
+    <div id="three" class="panel">Third panel</div>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/showcases/24-tabs-ink-ripple/script.js
+++ b/showcases/24-tabs-ink-ripple/script.js
@@ -1,0 +1,19 @@
+const tabs = document.querySelectorAll('.tabs button');
+const panels = document.querySelectorAll('.panel');
+const motion = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+tabs.forEach(btn => {
+  btn.addEventListener('click', e => {
+    panels.forEach(p => p.classList.toggle('active', p.id === btn.dataset.target));
+    tabs.forEach(b => b.setAttribute('aria-selected', b === btn));
+    if (!motion.matches) {
+      const rect = btn.getBoundingClientRect();
+      btn.style.setProperty('--x', `${e.clientX - rect.left}px`);
+      btn.style.setProperty('--y', `${e.clientY - rect.top}px`);
+      btn.classList.remove('ripple');
+      void btn.offsetWidth;
+      btn.classList.add('ripple');
+    }
+  });
+  btn.addEventListener('transitionend', () => btn.classList.remove('ripple'));
+});

--- a/showcases/24-tabs-ink-ripple/styles.css
+++ b/showcases/24-tabs-ink-ripple/styles.css
@@ -1,0 +1,47 @@
+body {
+  font-family: sans-serif;
+  padding: 2rem;
+}
+.tabs {
+  display: flex;
+  gap: .5rem;
+}
+.tabs button {
+  position: relative;
+  padding: .5rem 1rem;
+  background: #e0e0e0;
+  border: none;
+  cursor: pointer;
+  overflow: hidden;
+}
+.tabs button::after {
+  content: '';
+  position: absolute;
+  width: 200px;
+  height: 200px;
+  background: rgba(0,0,0,0.3);
+  border-radius: 50%;
+  top: var(--y);
+  left: var(--x);
+  transform: translate(-50%, -50%) scale(0);
+  opacity: 0;
+  transition: transform .4s, opacity .4s;
+}
+.tabs button.ripple::after {
+  transform: translate(-50%, -50%) scale(1);
+  opacity: 1;
+}
+.panels {
+  margin-top: 1rem;
+}
+.panel {
+  display: none;
+}
+.panel.active {
+  display: block;
+}
+@media (prefers-reduced-motion: reduce) {
+  .tabs button::after {
+    transition: none;
+  }
+}

--- a/showcases/25-input-focus-glow/README.md
+++ b/showcases/25-input-focus-glow/README.md
@@ -1,0 +1,5 @@
+# 25 — Input Focus Glow
+A breathing glow appears around a field when it or its contents are focused.
+## Accessibility
+- Uses `:focus-within` so keyboard users see the glow.
+- Respects `prefers-reduced-motion` by disabling the breathing animation.

--- a/showcases/25-input-focus-glow/index.html
+++ b/showcases/25-input-focus-glow/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Input Focus Glow</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <form class="field">
+    <label for="name">Name</label>
+    <input id="name" type="text" />
+  </form>
+</body>
+</html>

--- a/showcases/25-input-focus-glow/script.js
+++ b/showcases/25-input-focus-glow/script.js
@@ -1,0 +1,1 @@
+// No JavaScript needed for this demo.

--- a/showcases/25-input-focus-glow/styles.css
+++ b/showcases/25-input-focus-glow/styles.css
@@ -1,0 +1,33 @@
+body {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  background: #111;
+  font-family: sans-serif;
+  color: #fff;
+}
+.field {
+  padding: 1rem;
+  border-radius: 8px;
+  background: #222;
+}
+.field:focus-within {
+  animation: glow 2s ease-in-out infinite;
+}
+@keyframes glow {
+  0%,100% { box-shadow: 0 0 0 0 rgba(0,150,255,.7); }
+  50% { box-shadow: 0 0 10px 4px rgba(0,150,255,.7); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .field:focus-within {
+    animation: none;
+    box-shadow: 0 0 4px rgba(0,150,255,.7);
+  }
+}
+input {
+  background: #111;
+  border: none;
+  color: #fff;
+  padding: .5rem;
+}

--- a/showcases/26-password-strength-meter/README.md
+++ b/showcases/26-password-strength-meter/README.md
@@ -1,0 +1,5 @@
+# 26 — Password Strength Meter
+Bar widens and changes color based on password strength with hints.
+## Accessibility
+- Announces strength changes via `aria-live` region.
+- Respects `prefers-reduced-motion` to remove width transition.

--- a/showcases/26-password-strength-meter/index.html
+++ b/showcases/26-password-strength-meter/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Password Strength Meter</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <form class="box">
+    <label for="pass">Password</label>
+    <input id="pass" type="password" />
+    <div class="meter" aria-hidden="true"><div class="bar"></div></div>
+    <p id="hint" aria-live="polite"></p>
+  </form>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/showcases/26-password-strength-meter/script.js
+++ b/showcases/26-password-strength-meter/script.js
@@ -1,0 +1,22 @@
+const input = document.getElementById('pass');
+const bar = document.querySelector('.bar');
+const hint = document.getElementById('hint');
+
+function strength(val) {
+  let score = 0;
+  if (val.length > 5) score++;
+  if (val.length > 8) score++;
+  if (/[0-9]/.test(val)) score++;
+  if (/[^a-zA-Z0-9]/.test(val)) score++;
+  return score;
+}
+
+input.addEventListener('input', e => {
+  const s = strength(e.target.value);
+  const pct = (s / 4) * 100;
+  bar.style.width = pct + '%';
+  const colors = ['red','orange','gold','green'];
+  bar.style.background = colors[s - 1] || 'red';
+  const texts = ['Too short','Weak','Okay','Strong'];
+  hint.textContent = texts[s] || '';
+});

--- a/showcases/26-password-strength-meter/styles.css
+++ b/showcases/26-password-strength-meter/styles.css
@@ -1,0 +1,31 @@
+body {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  background: #f0f0f0;
+  font-family: sans-serif;
+}
+.box {
+  background: #fff;
+  padding: 1rem;
+  border-radius: 8px;
+}
+.meter {
+  height: 6px;
+  background: #ddd;
+  border-radius: 3px;
+  overflow: hidden;
+  margin-top: .5rem;
+}
+.bar {
+  height: 100%;
+  width: 0;
+  background: red;
+  transition: width .3s ease, background .3s ease;
+}
+@media (prefers-reduced-motion: reduce) {
+  .bar {
+    transition: none;
+  }
+}

--- a/showcases/27-search-autocomplete-pop/README.md
+++ b/showcases/27-search-autocomplete-pop/README.md
@@ -1,0 +1,5 @@
+# 27 — Search Autocomplete Pop
+Suggestions scale and fade in, navigable with keyboard.
+## Accessibility
+- Suggestions list uses ARIA roles for assistive tech.
+- Honors `prefers-reduced-motion` to disable pop animation.

--- a/showcases/27-search-autocomplete-pop/index.html
+++ b/showcases/27-search-autocomplete-pop/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Search Autocomplete Pop</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div class="search">
+    <input id="q" type="text" aria-autocomplete="list" aria-controls="list" />
+    <ul id="list" role="listbox"></ul>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/showcases/27-search-autocomplete-pop/script.js
+++ b/showcases/27-search-autocomplete-pop/script.js
@@ -1,0 +1,44 @@
+const input = document.getElementById('q');
+const list = document.getElementById('list');
+const data = ['Apple','Banana','Cherry','Date','Elderberry','Fig'];
+let index = -1;
+
+input.addEventListener('input', () => {
+  const val = input.value.toLowerCase();
+  list.innerHTML = '';
+  if (!val) { list.classList.remove('open'); return; }
+  data.filter(s => s.toLowerCase().startsWith(val)).forEach(s => {
+    const li = document.createElement('li');
+    li.textContent = s;
+    li.addEventListener('mousedown', () => {
+      input.value = s;
+      list.classList.remove('open');
+    });
+    list.appendChild(li);
+  });
+  index = -1;
+  list.classList.toggle('open', list.children.length > 0);
+});
+
+input.addEventListener('keydown', e => {
+  if (!list.classList.contains('open')) return;
+  const items = list.querySelectorAll('li');
+  if (e.key === 'ArrowDown') {
+    index = (index + 1) % items.length;
+  } else if (e.key === 'ArrowUp') {
+    index = (index - 1 + items.length) % items.length;
+  } else if (e.key === 'Enter' && index >= 0) {
+    input.value = items[index].textContent;
+    list.classList.remove('open');
+  } else {
+    return;
+  }
+  items.forEach((li, i) => li.classList.toggle('active', i === index));
+  e.preventDefault();
+});
+
+document.addEventListener('click', e => {
+  if (!list.contains(e.target) && e.target !== input) {
+    list.classList.remove('open');
+  }
+});

--- a/showcases/27-search-autocomplete-pop/styles.css
+++ b/showcases/27-search-autocomplete-pop/styles.css
@@ -1,0 +1,42 @@
+body {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  font-family: sans-serif;
+}
+.search {
+  position: relative;
+  width: 200px;
+}
+#list {
+  list-style: none;
+  margin: 4px 0 0;
+  padding: 0;
+  position: absolute;
+  width: 100%;
+  background: #fff;
+  border: 1px solid #ccc;
+  max-height: 150px;
+  overflow: auto;
+  transform-origin: top;
+  transform: scale(.95);
+  opacity: 0;
+  transition: transform .15s ease, opacity .15s ease;
+}
+#list.open {
+  transform: scale(1);
+  opacity: 1;
+}
+#list li {
+  padding: .25rem .5rem;
+  cursor: pointer;
+}
+#list li.active {
+  background: #eee;
+}
+@media (prefers-reduced-motion: reduce) {
+  #list {
+    transition: none;
+  }
+}

--- a/showcases/28-animated-placeholder-labels/README.md
+++ b/showcases/28-animated-placeholder-labels/README.md
@@ -1,0 +1,5 @@
+# 28 — Animated Placeholder Labels
+Labels float above inputs on focus/entry and shake on error.
+## Accessibility
+- Labels remain visible to aid users and screen readers.
+- Respects `prefers-reduced-motion` to disable shake animation.

--- a/showcases/28-animated-placeholder-labels/index.html
+++ b/showcases/28-animated-placeholder-labels/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Animated Placeholder Labels</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <form class="form">
+    <div class="field">
+      <input id="email" type="email" required placeholder=" " />
+      <label for="email">Email</label>
+    </div>
+    <button type="submit">Submit</button>
+  </form>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/showcases/28-animated-placeholder-labels/script.js
+++ b/showcases/28-animated-placeholder-labels/script.js
@@ -1,0 +1,9 @@
+const form = document.querySelector('.form');
+form.addEventListener('submit', e => {
+  if (!form.checkValidity()) {
+    e.preventDefault();
+    form.classList.remove('shake');
+    void form.offsetWidth;
+    form.classList.add('shake');
+  }
+});

--- a/showcases/28-animated-placeholder-labels/styles.css
+++ b/showcases/28-animated-placeholder-labels/styles.css
@@ -1,0 +1,48 @@
+body {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  font-family: sans-serif;
+}
+.field {
+  position: relative;
+  margin-bottom: 1rem;
+}
+input {
+  padding: .75rem .5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+label {
+  position: absolute;
+  left: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: #fff;
+  padding: 0 4px;
+  color: #777;
+  transition: .2s ease;
+  pointer-events: none;
+}
+.field input:focus + label,
+.field input:not(:placeholder-shown) + label {
+  top: 0;
+  transform: translateY(-100%);
+  font-size: .75rem;
+  color: #333;
+}
+.form.shake .field {
+  animation: shake .3s;
+}
+@keyframes shake {
+  10%, 90% { transform: translateX(-1px); }
+  20%, 80% { transform: translateX(2px); }
+  30%, 50%, 70% { transform: translateX(-4px); }
+  40%, 60% { transform: translateX(4px); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .form.shake .field {
+    animation: none;
+  }
+}

--- a/showcases/29-stepper-form-slide/README.md
+++ b/showcases/29-stepper-form-slide/README.md
@@ -1,0 +1,5 @@
+# 29 — Stepper Form with Slide
+Multi-step form that slides between steps.
+## Accessibility
+- Uses `aria-hidden` to hide inactive steps.
+- Respects `prefers-reduced-motion` to disable slide animation.

--- a/showcases/29-stepper-form-slide/index.html
+++ b/showcases/29-stepper-form-slide/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Stepper Form with Slide</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <form id="wizard">
+    <div class="steps">
+      <div class="step active" aria-hidden="false">
+      <label>Name <input type="text" required></label>
+      <button type="button" class="next">Next</button>
+    </div>
+    <div class="step" aria-hidden="true">
+      <label>Email <input type="email" required></label>
+      <div class="actions">
+        <button type="button" class="prev">Back</button>
+        <button type="submit">Submit</button>
+      </div>
+      </div>
+    </div>
+  </form>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/showcases/29-stepper-form-slide/script.js
+++ b/showcases/29-stepper-form-slide/script.js
@@ -1,0 +1,13 @@
+const steps = document.querySelector('.steps');
+const stepElems = document.querySelectorAll('.step');
+let current = 0;
+
+function show(i) {
+  steps.style.transform = `translateX(-${i * 100}%)`;
+  stepElems[current].setAttribute('aria-hidden', 'true');
+  stepElems[i].setAttribute('aria-hidden', 'false');
+  current = i;
+}
+
+document.querySelector('.next').addEventListener('click', () => show(1));
+document.querySelector('.prev').addEventListener('click', () => show(0));

--- a/showcases/29-stepper-form-slide/styles.css
+++ b/showcases/29-stepper-form-slide/styles.css
@@ -1,0 +1,33 @@
+body {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  font-family: sans-serif;
+}
+#wizard {
+  width: 260px;
+  overflow: hidden;
+}
+.steps {
+  display: flex;
+  transition: transform .3s ease;
+}
+.step {
+  width: 100%;
+  padding: 1rem;
+  box-sizing: border-box;
+}
+.step[aria-hidden="true"] {
+  pointer-events: none;
+}
+.actions {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 1rem;
+}
+@media (prefers-reduced-motion: reduce) {
+  .steps {
+    transition: none;
+  }
+}

--- a/showcases/30-drag-drop-sortable-list/README.md
+++ b/showcases/30-drag-drop-sortable-list/README.md
@@ -1,0 +1,5 @@
+# 30 — Drag & Drop Sortable List
+Native drag and drop reorders list items with animation.
+## Accessibility
+- Provides focus outlines and uses `aria-grabbed` state.
+- Respects `prefers-reduced-motion` to disable transition.

--- a/showcases/30-drag-drop-sortable-list/index.html
+++ b/showcases/30-drag-drop-sortable-list/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Drag & Drop Sortable List</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <ul id="sortable">
+    <li draggable="true">Item 1</li>
+    <li draggable="true">Item 2</li>
+    <li draggable="true">Item 3</li>
+    <li draggable="true">Item 4</li>
+  </ul>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/showcases/30-drag-drop-sortable-list/script.js
+++ b/showcases/30-drag-drop-sortable-list/script.js
@@ -1,0 +1,24 @@
+const list = document.getElementById('sortable');
+let dragged = null;
+
+list.addEventListener('dragstart', e => {
+  dragged = e.target;
+  e.target.classList.add('dragging');
+  e.target.setAttribute('aria-grabbed', 'true');
+});
+
+list.addEventListener('dragend', e => {
+  e.target.classList.remove('dragging');
+  e.target.removeAttribute('aria-grabbed');
+});
+
+list.addEventListener('dragover', e => {
+  e.preventDefault();
+  const items = [...list.querySelectorAll('li:not(.dragging)')];
+  const next = items.find(item => e.clientY <= item.getBoundingClientRect().top + item.offsetHeight / 2);
+  if (next) {
+    list.insertBefore(dragged, next);
+  } else {
+    list.appendChild(dragged);
+  }
+});

--- a/showcases/30-drag-drop-sortable-list/styles.css
+++ b/showcases/30-drag-drop-sortable-list/styles.css
@@ -1,0 +1,28 @@
+body {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  font-family: sans-serif;
+}
+#sortable {
+  list-style: none;
+  padding: 0;
+  width: 200px;
+}
+#sortable li {
+  padding: .5rem 1rem;
+  margin-bottom: .25rem;
+  background: #f0f0f0;
+  border: 1px solid #ccc;
+  cursor: move;
+  transition: transform .2s;
+}
+#sortable li.dragging {
+  opacity: .5;
+}
+@media (prefers-reduced-motion: reduce) {
+  #sortable li {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add circular progress tick, rating stars, accordion, ink ripple tabs, input glow, password meter, autocomplete, floating labels, stepper form, and sortable list demos
- include new showcases in gallery index

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896dcfcdc448333882647f42c63f08b