### PR TITLE
Add tooltip smart placement demo

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,6 +97,7 @@
       { title: 'Floating Labels Textarea', path: 'showcases/38-floating-labels-textarea/index.html' },
       { title: 'Tag Chips Enter', path: 'showcases/39-tag-chips-enter/index.html' },
       { title: 'Notification Bell Shake', path: 'showcases/40-notification-bell-shake/index.html' },
+      { title: 'Tooltip with Smart Placement', path: 'showcases/41-tooltip-smart-placement/index.html' },
     ];
     const menu = document.getElementById('menu');
     const frame = document.getElementById('frame');

--- a/showcases/41-tooltip-smart-placement/README.md
+++ b/showcases/41-tooltip-smart-placement/README.md
@@ -1,0 +1,8 @@
+# Tooltip with Smart Placement
+
+Demonstrates a tooltip that flips its placement when it would otherwise overflow the viewport edges. Utilizes JavaScript to detect available space around the target element and updates a `data-placement` attribute consumed by CSS.
+
+## Notes
+- Uses `pointerenter`/`pointerleave` and `focus`/`blur` for accessibility.
+- Flips between top and bottom, and left and right depending on viewport boundaries.
+- Respects `prefers-reduced-motion` to disable animation.

--- a/showcases/41-tooltip-smart-placement/index.html
+++ b/showcases/41-tooltip-smart-placement/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Tooltip Smart Placement</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div class="wrap">
+    <button id="target" aria-describedby="tip">Hover me</button>
+    <div id="tip" class="tooltip" role="tooltip" hidden>I'm a tooltip that flips!</div>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/showcases/41-tooltip-smart-placement/script.js
+++ b/showcases/41-tooltip-smart-placement/script.js
@@ -1,0 +1,53 @@
+const target = document.getElementById('target');
+const tip = document.getElementById('tip');
+
+function place() {
+  const rect = target.getBoundingClientRect();
+  const tipRect = tip.getBoundingClientRect();
+
+  let top = rect.top - tipRect.height - 8;
+  let left = rect.left + rect.width / 2 - tipRect.width / 2;
+  let placement = 'top';
+
+  if (top < 0) {
+    top = rect.bottom + 8;
+    placement = 'bottom';
+  }
+
+  if (left < 0) {
+    left = rect.left;
+    top = rect.top + rect.height / 2 - tipRect.height / 2;
+    placement = 'left';
+  } else if (left + tipRect.width > window.innerWidth) {
+    left = rect.right - tipRect.width;
+    top = rect.top + rect.height / 2 - tipRect.height / 2;
+    placement = 'right';
+  }
+
+  tip.style.top = `${top}px`;
+  tip.style.left = `${left}px`;
+  tip.setAttribute('data-placement', placement);
+}
+
+function show() {
+  tip.hidden = false;
+  tip.setAttribute('data-show', '');
+  place();
+}
+
+function hide() {
+  tip.hidden = true;
+  tip.removeAttribute('data-show');
+}
+
+target.addEventListener('pointerenter', show);
+target.addEventListener('pointerleave', hide);
+target.addEventListener('focus', show);
+target.addEventListener('blur', hide);
+
+window.addEventListener('scroll', () => {
+  if (!tip.hidden) place();
+});
+window.addEventListener('resize', () => {
+  if (!tip.hidden) place();
+});

--- a/showcases/41-tooltip-smart-placement/styles.css
+++ b/showcases/41-tooltip-smart-placement/styles.css
@@ -1,0 +1,72 @@
+body {
+  margin: 0;
+  height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: system-ui, sans-serif;
+}
+
+button {
+  padding: 0.6rem 1rem;
+  font-size: 1rem;
+}
+
+.tooltip {
+  position: fixed;
+  padding: 0.4rem 0.6rem;
+  background: #333;
+  color: #fff;
+  border-radius: 4px;
+  font-size: 0.875rem;
+  pointer-events: none;
+  opacity: 0;
+  transform: scale(0.9);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  white-space: nowrap;
+  z-index: 1000;
+}
+
+.tooltip[data-show] {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.tooltip::after {
+  content: '';
+  position: absolute;
+  width: 8px;
+  height: 8px;
+  background: inherit;
+  transform: rotate(45deg);
+}
+
+.tooltip[data-placement="top"]::after {
+  bottom: -4px;
+  left: 50%;
+  transform: translateX(-50%) rotate(45deg);
+}
+
+.tooltip[data-placement="bottom"]::after {
+  top: -4px;
+  left: 50%;
+  transform: translateX(-50%) rotate(45deg);
+}
+
+.tooltip[data-placement="left"]::after {
+  right: -4px;
+  top: 50%;
+  transform: translateY(-50%) rotate(45deg);
+}
+
+.tooltip[data-placement="right"]::after {
+  left: -4px;
+  top: 50%;
+  transform: translateY(-50%) rotate(45deg);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tooltip {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add new showcase demonstrating tooltip smart placement that flips when near viewport edges
- register demo in main gallery

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68982deb55c48333a742eb622933112c