### PR TITLE
feat: animate text reveal on scroll

### DIFF
--- a/showcases/09-text-reveal-on-scroll/README.md
+++ b/showcases/09-text-reveal-on-scroll/README.md
@@ -1,6 +1,6 @@
 # 09 — Text Reveal on Scroll
 
-Text blocks reveal with a sliding clip-path as they enter the viewport using Intersection Observer.
+Text blocks slide in with a `clip-path` mask and subtle fade/translate animation as they enter the viewport using Intersection Observer.
 
 ## Accessibility
 - Elements reveal instantly when `prefers-reduced-motion` is detected.

--- a/showcases/09-text-reveal-on-scroll/index.html
+++ b/showcases/09-text-reveal-on-scroll/index.html
@@ -1,14 +1,15 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta charset="UTF-8" />
-<title>Text Reveal on Scroll</title>
-<link rel="stylesheet" href="styles.css" />
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Text Reveal on Scroll</title>
+  <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-<section class="reveal">First section of text to reveal.</section>
-<section class="reveal">Another section comes into view.</section>
-<section class="reveal">Final bit of text revealed on scroll.</section>
-<script src="script.js"></script>
+  <section class="reveal">First section of text to reveal.</section>
+  <section class="reveal">Another section comes into view.</section>
+  <section class="reveal">Final bit of text revealed on scroll.</section>
+  <script src="script.js"></script>
 </body>
 </html>

--- a/showcases/09-text-reveal-on-scroll/script.js
+++ b/showcases/09-text-reveal-on-scroll/script.js
@@ -1,16 +1,20 @@
-const blocks = document.querySelectorAll('.reveal');
-const motion = window.matchMedia('(prefers-reduced-motion: reduce)');
+const sections = document.querySelectorAll('.reveal');
+const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
 
-if (motion.matches) {
-  blocks.forEach(b => b.classList.add('visible'));
+if (prefersReducedMotion.matches) {
+  sections.forEach(section => section.classList.add('visible'));
 } else {
-  const io = new IntersectionObserver(entries => {
-    entries.forEach(entry => {
+  const observer = new IntersectionObserver((entries, obs) => {
+    for (const entry of entries) {
       if (entry.isIntersecting) {
         entry.target.classList.add('visible');
-        io.unobserve(entry.target);
+        obs.unobserve(entry.target);
       }
-    });
-  }, { threshold: 0.2 });
-  blocks.forEach(b => io.observe(b));
+    }
+  }, {
+    threshold: 0.15,
+    rootMargin: '0px 0px -10% 0px'
+  });
+
+  sections.forEach(section => observer.observe(section));
 }

--- a/showcases/09-text-reveal-on-scroll/styles.css
+++ b/showcases/09-text-reveal-on-scroll/styles.css
@@ -2,23 +2,42 @@ body {
   margin: 0;
   font-family: system-ui, sans-serif;
 }
+
 section {
   min-height: 100vh;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 2rem;
+  font-size: clamp(1.5rem, 5vw, 3rem);
+  padding: 0 1rem;
+  background: #111;
+  color: #fff;
 }
+
+section:nth-child(even) {
+  background: #1b1b1b;
+}
+
 .reveal {
   clip-path: inset(0 100% 0 0);
-  transition: clip-path 0.6s ease-out;
+  opacity: 0;
+  transform: translateY(2rem);
+  transition: clip-path 0.6s ease-out, opacity 0.6s ease-out,
+    transform 0.6s ease-out;
+  will-change: clip-path, opacity, transform;
 }
+
 .reveal.visible {
   clip-path: inset(0 0 0 0);
+  opacity: 1;
+  transform: none;
 }
+
 @media (prefers-reduced-motion: reduce) {
   .reveal {
     clip-path: none;
+    opacity: 1;
+    transform: none;
     transition: none;
   }
 }


### PR DESCRIPTION
## Summary
- refine Text Reveal on Scroll showcase with viewport meta tag
- add modern fade-and-slide animation using `clip-path` and IntersectionObserver
- document enhanced effect

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68984832438c8333baee778017a0136b