### PR TITLE
Add showcase demos 43-49

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,6 +57,7 @@
   </div>
   <script>
     const showcases = [
+
       { title: '3D Card Tilt', path: 'showcases/01-3d-card-tilt/index.html' },
       { title: 'Glassmorphism Cards', path: 'showcases/02-glassmorphism-cards/index.html' },
       { title: 'Neumorphic Toggle', path: 'showcases/03-neumorphic-toggle/index.html' },
@@ -99,6 +100,13 @@
       { title: 'Notification Bell Shake', path: 'showcases/40-notification-bell-shake/index.html' },
       { title: 'Tooltip with Smart Placement', path: 'showcases/41-tooltip-smart-placement/index.html' },
       { title: 'Popover Spring Open', path: 'showcases/42-popover-spring-open/index.html' },
+      { title: 'Hover Card with Preview', path: 'showcases/43-hover-card-preview/index.html' },
+      { title: 'Custom Context Menu', path: 'showcases/44-context-menu-custom/index.html' },
+      { title: 'Command Palette', path: 'showcases/45-command-palette/index.html' },
+      { title: 'Animated Scrollspy Nav', path: 'showcases/46-animated-scrollspy-nav/index.html' },
+      { title: 'Sticky Header Shrink', path: 'showcases/47-sticky-header-shrink/index.html' },
+      { title: 'Breadcrumb Trail Shine', path: 'showcases/48-breadcrumb-trail-shine/index.html' },
+      { title: 'Data Table Row Expand', path: 'showcases/49-data-table-row-expand/index.html' },
     ];
     const menu = document.getElementById('menu');
     const frame = document.getElementById('frame');

--- a/showcases/43-hover-card-preview/README.md
+++ b/showcases/43-hover-card-preview/README.md
@@ -1,0 +1,3 @@
+# Hover Card with Preview
+
+Shows a preview image only when hover intent is detected (slight delay) and fades it in. Uses a simple timer and opacity transition; respects reduced motion.

--- a/showcases/43-hover-card-preview/index.html
+++ b/showcases/43-hover-card-preview/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Hover Card with Preview</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div class="card" tabindex="0">
+    <div class="preview">
+      <img src="https://picsum.photos/300/180" alt="Preview" />
+    </div>
+    <div class="content">
+      <h3>Hover me</h3>
+      <p>Delayed intent + fade preview.</p>
+    </div>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/showcases/43-hover-card-preview/script.js
+++ b/showcases/43-hover-card-preview/script.js
@@ -1,0 +1,16 @@
+const card = document.querySelector('.card');
+let intent;
+card.addEventListener('mouseenter', () => {
+  intent = setTimeout(() => card.classList.add('show'), 200);
+});
+card.addEventListener('mouseleave', () => {
+  clearTimeout(intent);
+  card.classList.remove('show');
+});
+card.addEventListener('focus', () => {
+  intent = setTimeout(() => card.classList.add('show'), 200);
+});
+card.addEventListener('blur', () => {
+  clearTimeout(intent);
+  card.classList.remove('show');
+});

--- a/showcases/43-hover-card-preview/styles.css
+++ b/showcases/43-hover-card-preview/styles.css
@@ -1,0 +1,39 @@
+body {
+  font-family: sans-serif;
+  margin: 0;
+  height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.card {
+  position: relative;
+  width: 260px;
+  border: 1px solid #ccc;
+  padding: 1rem;
+  cursor: pointer;
+  overflow: hidden;
+}
+.preview {
+  position: absolute;
+  inset: 0;
+  background: #000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s;
+}
+.preview img {
+  max-width: 100%;
+  height: auto;
+}
+.card.show .preview {
+  opacity: 1;
+}
+@media (prefers-reduced-motion: reduce) {
+  .preview {
+    transition: none;
+  }
+}

--- a/showcases/44-context-menu-custom/README.md
+++ b/showcases/44-context-menu-custom/README.md
@@ -1,0 +1,3 @@
+# Custom Context Menu
+
+Replaces the default right-click menu with a styled list that reveals with a scale and fade animation at the cursor position. Click or press Escape to dismiss.

--- a/showcases/44-context-menu-custom/index.html
+++ b/showcases/44-context-menu-custom/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Custom Context Menu</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div class="area">Right-click anywhere</div>
+  <ul class="menu" role="menu">
+    <li tabindex="0">Action 1</li>
+    <li tabindex="0">Action 2</li>
+    <li tabindex="0">Action 3</li>
+  </ul>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/showcases/44-context-menu-custom/script.js
+++ b/showcases/44-context-menu-custom/script.js
@@ -1,0 +1,21 @@
+const menu = document.querySelector('.menu');
+let visible = false;
+document.addEventListener('contextmenu', e => {
+  e.preventDefault();
+  menu.style.top = e.pageY + 'px';
+  menu.style.left = e.pageX + 'px';
+  menu.classList.add('show');
+  visible = true;
+});
+document.addEventListener('click', () => {
+  if (visible) {
+    menu.classList.remove('show');
+    visible = false;
+  }
+});
+document.addEventListener('keydown', e => {
+  if (e.key === 'Escape') {
+    menu.classList.remove('show');
+    visible = false;
+  }
+});

--- a/showcases/44-context-menu-custom/styles.css
+++ b/showcases/44-context-menu-custom/styles.css
@@ -1,0 +1,43 @@
+body {
+  height: 100vh;
+  margin: 0;
+  font-family: sans-serif;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.area {
+  flex: 1;
+  text-align: center;
+}
+.menu {
+  position: absolute;
+  list-style: none;
+  margin: 0;
+  padding: 0.5rem 0;
+  background: #fff;
+  border: 1px solid #ccc;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+  transform: scale(0.8);
+  opacity: 0;
+  pointer-events: none;
+  transition: transform 0.15s ease, opacity 0.15s ease;
+}
+.menu.show {
+  transform: scale(1);
+  opacity: 1;
+  pointer-events: auto;
+}
+.menu li {
+  padding: 0.5rem 1.5rem;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.menu li:hover {
+  background: #eee;
+}
+@media (prefers-reduced-motion: reduce) {
+  .menu {
+    transition: none;
+  }
+}

--- a/showcases/45-command-palette/README.md
+++ b/showcases/45-command-palette/README.md
@@ -1,0 +1,3 @@
+# Command Palette
+
+Press `⌘K`/`Ctrl+K` or the button to open an overlay with a filterable list of commands. Items stagger in with a short animation and respect reduced motion.

--- a/showcases/45-command-palette/index.html
+++ b/showcases/45-command-palette/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Command Palette</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <button id="open">Open Palette (⌘K)</button>
+  <div class="overlay" hidden>
+    <div class="palette">
+      <input type="text" aria-label="Command" placeholder="Type a command" />
+      <ul>
+        <li>Open File</li>
+        <li>Save All</li>
+        <li>Toggle Sidebar</li>
+        <li>Close Window</li>
+      </ul>
+    </div>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/showcases/45-command-palette/script.js
+++ b/showcases/45-command-palette/script.js
@@ -1,0 +1,37 @@
+const overlay = document.querySelector('.overlay');
+const input = overlay.querySelector('input');
+const items = Array.from(overlay.querySelectorAll('li'));
+const openBtn = document.getElementById('open');
+const motion = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+function openPalette() {
+  overlay.hidden = false;
+  input.value = '';
+  items.forEach((li, i) => {
+    li.style.transitionDelay = motion.matches ? '0ms' : `${i * 50}ms`;
+    li.classList.add('show');
+    li.style.display = 'block';
+  });
+  input.focus();
+}
+function closePalette() {
+  overlay.hidden = true;
+  items.forEach(li => li.classList.remove('show'));
+}
+openBtn.addEventListener('click', openPalette);
+document.addEventListener('keydown', e => {
+  if ((e.key === 'k' && (e.metaKey || e.ctrlKey))) {
+    e.preventDefault();
+    openPalette();
+  }
+  if (e.key === 'Escape') closePalette();
+});
+overlay.addEventListener('click', e => {
+  if (e.target === overlay) closePalette();
+});
+input.addEventListener('input', () => {
+  const q = input.value.toLowerCase();
+  items.forEach(li => {
+    li.style.display = li.textContent.toLowerCase().includes(q) ? 'block' : 'none';
+  });
+});

--- a/showcases/45-command-palette/styles.css
+++ b/showcases/45-command-palette/styles.css
@@ -1,0 +1,56 @@
+body {
+  font-family: sans-serif;
+  margin: 0;
+  height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+#open {
+  padding: 0.5rem 1rem;
+}
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.4);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 10vh;
+}
+.palette {
+  background: #fff;
+  padding: 1rem;
+  border-radius: 8px;
+  width: 300px;
+  box-shadow: 0 10px 30px rgba(0,0,0,0.2);
+}
+.palette input {
+  width: 100%;
+  padding: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+.palette ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+.palette li {
+  padding: 0.4rem;
+  border-radius: 4px;
+  opacity: 0;
+  transform: translateY(4px);
+  transition: opacity 0.2s, transform 0.2s;
+}
+.palette li.show {
+  opacity: 1;
+  transform: translateY(0);
+}
+.palette li:hover {
+  background: #eee;
+}
+@media (prefers-reduced-motion: reduce) {
+  .palette li {
+    transition: none;
+  }
+}

--- a/showcases/46-animated-scrollspy-nav/README.md
+++ b/showcases/46-animated-scrollspy-nav/README.md
@@ -1,0 +1,3 @@
+# Animated Scrollspy Nav
+
+Navigation links smoothly scroll to sections and an indicator bar moves to highlight the active section using `IntersectionObserver`.

--- a/showcases/46-animated-scrollspy-nav/index.html
+++ b/showcases/46-animated-scrollspy-nav/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Animated Scrollspy Nav</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <nav class="spy">
+    <a href="#sec1">Section 1</a>
+    <a href="#sec2">Section 2</a>
+    <a href="#sec3">Section 3</a>
+    <span class="indicator"></span>
+  </nav>
+  <section id="sec1" class="panel">Section 1</section>
+  <section id="sec2" class="panel">Section 2</section>
+  <section id="sec3" class="panel">Section 3</section>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/showcases/46-animated-scrollspy-nav/script.js
+++ b/showcases/46-animated-scrollspy-nav/script.js
@@ -1,0 +1,30 @@
+const links = document.querySelectorAll('.spy a');
+const indicator = document.querySelector('.indicator');
+const sections = document.querySelectorAll('.panel');
+const motion = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+links.forEach(link => {
+  link.addEventListener('click', e => {
+    e.preventDefault();
+    document.querySelector(link.getAttribute('href')).scrollIntoView({behavior: motion.matches ? 'auto' : 'smooth'});
+  });
+});
+
+function moveIndicator(link) {
+  const rect = link.getBoundingClientRect();
+  indicator.style.width = rect.width + 'px';
+  indicator.style.transform = `translateX(${link.offsetLeft}px)`;
+}
+
+window.addEventListener('load', () => moveIndicator(links[0]));
+
+const observer = new IntersectionObserver(entries => {
+  entries.forEach(entry => {
+    if (entry.isIntersecting) {
+      const active = document.querySelector(`.spy a[href="#${entry.target.id}"]`);
+      moveIndicator(active);
+    }
+  });
+}, {threshold: 0.6});
+
+sections.forEach(sec => observer.observe(sec));

--- a/showcases/46-animated-scrollspy-nav/styles.css
+++ b/showcases/46-animated-scrollspy-nav/styles.css
@@ -1,0 +1,43 @@
+body {
+  margin: 0;
+  font-family: sans-serif;
+}
+.spy {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  justify-content: center;
+  background: #fff;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.1);
+  z-index: 10;
+}
+.spy a {
+  padding: 1rem;
+  text-decoration: none;
+  color: #333;
+  position: relative;
+}
+.spy .indicator {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  height: 3px;
+  background: #007aff;
+  width: 0;
+  transform: translateX(0);
+  transition: transform 0.2s, width 0.2s;
+}
+.panel {
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 2rem;
+}
+@media (prefers-reduced-motion: reduce) {
+  .spy .indicator {
+    transition: none;
+  }
+}

--- a/showcases/47-sticky-header-shrink/README.md
+++ b/showcases/47-sticky-header-shrink/README.md
@@ -1,0 +1,3 @@
+# Sticky Header Shrink
+
+A fixed header that smoothly reduces its height and font size once the page is scrolled beyond a threshold, providing more screen space.

--- a/showcases/47-sticky-header-shrink/index.html
+++ b/showcases/47-sticky-header-shrink/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Sticky Header Shrink</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header>My Site</header>
+  <main>
+    <p>Scroll down to shrink the header.</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+    <p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+    <p>Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>
+    <p>Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+    <p>More filler text.</p>
+    <p>More filler text.</p>
+    <p>More filler text.</p>
+    <p>More filler text.</p>
+    <p>More filler text.</p>
+  </main>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/showcases/47-sticky-header-shrink/script.js
+++ b/showcases/47-sticky-header-shrink/script.js
@@ -1,0 +1,4 @@
+const header = document.querySelector('header');
+window.addEventListener('scroll', () => {
+  header.classList.toggle('shrink', window.scrollY > 80);
+});

--- a/showcases/47-sticky-header-shrink/styles.css
+++ b/showcases/47-sticky-header-shrink/styles.css
@@ -1,0 +1,32 @@
+body {
+  margin: 0;
+  font-family: sans-serif;
+}
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 80px;
+  background: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.5rem;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.1);
+  transition: height 0.2s, font-size 0.2s;
+  z-index: 10;
+}
+header.shrink {
+  height: 50px;
+  font-size: 1.1rem;
+}
+main {
+  margin-top: 80px;
+  padding: 1rem;
+}
+@media (prefers-reduced-motion: reduce) {
+  header {
+    transition: none;
+  }
+}

--- a/showcases/48-breadcrumb-trail-shine/README.md
+++ b/showcases/48-breadcrumb-trail-shine/README.md
@@ -1,0 +1,3 @@
+# Breadcrumb Trail Shine
+
+Breadcrumb links get a subtle moving sheen using a skewed linear-gradient on a pseudo-element animated across each link.

--- a/showcases/48-breadcrumb-trail-shine/index.html
+++ b/showcases/48-breadcrumb-trail-shine/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Breadcrumb Trail Shine</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <nav class="crumbs">
+    <a href="#">Home</a>
+    <a href="#">Library</a>
+    <a href="#">Data</a>
+  </nav>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/showcases/48-breadcrumb-trail-shine/script.js
+++ b/showcases/48-breadcrumb-trail-shine/script.js
@@ -1,0 +1,1 @@
+// No JavaScript needed for this CSS-only sheen effect.

--- a/showcases/48-breadcrumb-trail-shine/styles.css
+++ b/showcases/48-breadcrumb-trail-shine/styles.css
@@ -1,0 +1,36 @@
+body {
+  font-family: sans-serif;
+  padding: 2rem;
+}
+.crumbs {
+  display: flex;
+  gap: 0.5rem;
+}
+.crumbs a {
+  position: relative;
+  padding: 0.25rem 0.5rem;
+  color: #555;
+  text-decoration: none;
+  overflow: hidden;
+}
+.crumbs a::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: -100%;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(120deg, transparent, rgba(255,255,255,0.6), transparent);
+  transform: skewX(-20deg);
+  animation: shine 3s infinite;
+}
+@keyframes shine {
+  to {
+    left: 200%;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .crumbs a::after {
+    animation: none;
+  }
+}

--- a/showcases/49-data-table-row-expand/README.md
+++ b/showcases/49-data-table-row-expand/README.md
@@ -1,0 +1,3 @@
+# Data Table Row Expand
+
+Click a table row to reveal a detail panel that slides down beneath it. The panel height is animated using `max-height` for a smooth expand/collapse.

--- a/showcases/49-data-table-row-expand/index.html
+++ b/showcases/49-data-table-row-expand/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Data Table Row Expand</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <table>
+    <tr class="row" tabindex="0"><td>Item A</td><td>42</td></tr>
+    <tr class="detail"><td colspan="2"><div class="panel">More details about Item A.</div></td></tr>
+    <tr class="row" tabindex="0"><td>Item B</td><td>81</td></tr>
+    <tr class="detail"><td colspan="2"><div class="panel">More details about Item B.</div></td></tr>
+    <tr class="row" tabindex="0"><td>Item C</td><td>16</td></tr>
+    <tr class="detail"><td colspan="2"><div class="panel">More details about Item C.</div></td></tr>
+  </table>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/showcases/49-data-table-row-expand/script.js
+++ b/showcases/49-data-table-row-expand/script.js
@@ -1,0 +1,15 @@
+const rows = document.querySelectorAll('tr.row');
+rows.forEach(row => {
+  const detail = row.nextElementSibling;
+  const panel = detail.querySelector('.panel');
+  row.addEventListener('click', () => {
+    const open = detail.classList.toggle('open');
+    panel.style.maxHeight = open ? panel.scrollHeight + 'px' : 0;
+  });
+  row.addEventListener('keydown', e => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      row.click();
+    }
+  });
+});

--- a/showcases/49-data-table-row-expand/styles.css
+++ b/showcases/49-data-table-row-expand/styles.css
@@ -1,0 +1,22 @@
+body {
+  font-family: sans-serif;
+  padding: 2rem;
+}
+table {
+  border-collapse: collapse;
+  width: 300px;
+}
+td {
+  border: 1px solid #ccc;
+  padding: 0.5rem;
+}
+.detail .panel {
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.25s ease;
+}
+@media (prefers-reduced-motion: reduce) {
+  .detail .panel {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary
- implement Hover Card with Preview using delayed intent fade-in
- add Custom Context Menu with reveal animation
- create Command Palette overlay with searchable list
- build Animated Scrollspy Nav and Sticky Header Shrink effects
- include Breadcrumb Trail Shine and Data Table Row Expand demos

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68984aa14f28833384043ec4fc21db7d