### PR TITLE
feat: add showcases 61-70

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,12 +113,22 @@
       { title: 'Dynamic Blob Background', path: 'showcases/53-dynamic-blob-background/index.html' },
       { title: 'Gooey Menu Toggle', path: 'showcases/54-gooey-menu-toggle/index.html' },
       { title: 'Lottie-like Path Drawing', path: 'showcases/55-lottie-like-path-drawing/index.html' },
-      { title: 'Particle Background', path: 'showcases/56-particle-background/index.html' },
-      { title: 'Cursor-Follower Dot', path: 'showcases/57-cursor-follower-dot/index.html' },
-      { title: 'Magnetic Cursor Halo', path: 'showcases/58-magnetic-cursor-halo/index.html' },
-      { title: 'Noise Overlay Film', path: 'showcases/59-noise-overlay-film/index.html' },
-      { title: 'Text Scramble Effect', path: 'showcases/60-text-scramble-effect/index.html' },
-    ];
+        { title: 'Particle Background', path: 'showcases/56-particle-background/index.html' },
+        { title: 'Cursor-Follower Dot', path: 'showcases/57-cursor-follower-dot/index.html' },
+        { title: 'Magnetic Cursor Halo', path: 'showcases/58-magnetic-cursor-halo/index.html' },
+        { title: 'Noise Overlay Film', path: 'showcases/59-noise-overlay-film/index.html' },
+        { title: 'Text Scramble Effect', path: 'showcases/60-text-scramble-effect/index.html' },
+        { title: 'Typewriter with Caret', path: 'showcases/61-typewriter-caret/index.html' },
+        { title: 'Gradient Text Shine', path: 'showcases/62-gradient-text-shine/index.html' },
+        { title: 'Section Divider Waves', path: 'showcases/63-section-divider-waves/index.html' },
+        { title: 'Diagonal Reveal Panels', path: 'showcases/64-diagonal-reveal-panels/index.html' },
+        { title: 'Timeline with Scroll Progress', path: 'showcases/65-timeline-scroll-progress/index.html' },
+        { title: 'Card Stack Depth on Scroll', path: 'showcases/66-card-stack-depth-scroll/index.html' },
+        { title: '3D Coverflow Gallery', path: 'showcases/67-3d-coverflow-gallery/index.html' },
+        { title: 'Tilted Content Sections', path: 'showcases/68-tilted-content-sections/index.html' },
+        { title: 'Sticky Image Gallery', path: 'showcases/69-sticky-image-gallery/index.html' },
+        { title: 'Scroll-Triggered Counter', path: 'showcases/70-scroll-triggered-counter/index.html' },
+      ];
     const menu = document.getElementById('menu');
     const frame = document.getElementById('frame');
     showcases.forEach((s, i) => {

--- a/showcases/61-typewriter-caret/index.html
+++ b/showcases/61-typewriter-caret/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Typewriter with Caret</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <h1 class="type">Typewriter Effect</h1>
+</body>
+</html>

--- a/showcases/61-typewriter-caret/styles.css
+++ b/showcases/61-typewriter-caret/styles.css
@@ -1,0 +1,23 @@
+body{
+  margin:0;
+  height:100vh;
+  display:flex;
+  justify-content:center;
+  align-items:center;
+  background:#111;
+  color:#fff;
+}
+.type{
+  font-family:monospace;
+  white-space:nowrap;
+  overflow:hidden;
+  border-right:2px solid #fff;
+  width:17ch;
+  animation:typing 4s steps(17,end), blink .75s step-end infinite;
+}
+@keyframes typing{
+  from{width:0}
+}
+@keyframes blink{
+  50%{border-color:transparent}
+}

--- a/showcases/62-gradient-text-shine/index.html
+++ b/showcases/62-gradient-text-shine/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Gradient Text Shine</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <h1 class="shine">Shiny Text</h1>
+</body>
+</html>

--- a/showcases/62-gradient-text-shine/styles.css
+++ b/showcases/62-gradient-text-shine/styles.css
@@ -1,0 +1,20 @@
+body{
+  margin:0;
+  height:100vh;
+  display:flex;
+  justify-content:center;
+  align-items:center;
+  background:#111;
+}
+.shine{
+  font-size:4rem;
+  background:linear-gradient(90deg,#fff,#888,#fff);
+  background-size:200%;
+  -webkit-background-clip:text;
+  color:transparent;
+  animation:shine 2s linear infinite;
+}
+@keyframes shine{
+  from{background-position:200%}
+  to{background-position:-200%}
+}

--- a/showcases/63-section-divider-waves/index.html
+++ b/showcases/63-section-divider-waves/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Section Divider Waves</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <section class="first"><h1>First Section</h1></section>
+  <div class="wave">
+    <svg viewBox="0 0 1440 320" preserveAspectRatio="none"><path fill="#fff" d="M0,192L60,186.7C120,181,240,171,360,165.3C480,160,600,160,720,176C840,192,960,224,1080,213.3C1200,203,1320,149,1380,122.7L1440,96V320H0Z"></path></svg>
+  </div>
+  <section class="second"><h1>Second Section</h1></section>
+</body>
+</html>

--- a/showcases/63-section-divider-waves/styles.css
+++ b/showcases/63-section-divider-waves/styles.css
@@ -1,0 +1,6 @@
+body{margin:0;font-family:sans-serif;}
+section{height:100vh;display:flex;align-items:center;justify-content:center;font-size:3rem;}
+.first{background:#4facfe;color:#fff;}
+.second{background:#fff;color:#333;}
+.wave{line-height:0;background:#4facfe;}
+.wave svg{display:block;width:100%;height:100px;}

--- a/showcases/64-diagonal-reveal-panels/index.html
+++ b/showcases/64-diagonal-reveal-panels/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Diagonal Reveal Panels</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div class="panels">
+    <div class="panel"><img src="https://picsum.photos/seed/a/600/400" alt=""><div class="mask"></div></div>
+    <div class="panel"><img src="https://picsum.photos/seed/b/600/400" alt=""><div class="mask"></div></div>
+    <div class="panel"><img src="https://picsum.photos/seed/c/600/400" alt=""><div class="mask"></div></div>
+  </div>
+</body>
+</html>

--- a/showcases/64-diagonal-reveal-panels/styles.css
+++ b/showcases/64-diagonal-reveal-panels/styles.css
@@ -1,0 +1,8 @@
+body{margin:0;height:100vh;}
+.panels{display:flex;height:100%;}
+.panel{flex:1;position:relative;overflow:hidden;}
+.panel img{width:100%;height:100%;object-fit:cover;}
+.mask{position:absolute;top:0;left:0;width:120%;height:100%;background:#fff;transform:skewX(-20deg) translateX(-100%);animation:reveal 2s forwards;}
+.panel:nth-child(2) .mask{animation-delay:.5s;}
+.panel:nth-child(3) .mask{animation-delay:1s;}
+@keyframes reveal{to{transform:skewX(-20deg) translateX(120%);}}

--- a/showcases/65-timeline-scroll-progress/index.html
+++ b/showcases/65-timeline-scroll-progress/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Timeline with Scroll Progress</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div class="timeline">
+    <div class="event">Start</div>
+    <div class="event">Middle</div>
+    <div class="event">End</div>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/showcases/65-timeline-scroll-progress/script.js
+++ b/showcases/65-timeline-scroll-progress/script.js
@@ -1,0 +1,7 @@
+const events=document.querySelectorAll('.event');
+const obs=new IntersectionObserver(entries=>{
+  entries.forEach(entry=>{
+    if(entry.isIntersecting){entry.target.classList.add('active');}
+  });
+},{threshold:0.5});
+events.forEach(e=>obs.observe(e));

--- a/showcases/65-timeline-scroll-progress/styles.css
+++ b/showcases/65-timeline-scroll-progress/styles.css
@@ -1,0 +1,6 @@
+body{margin:0;height:200vh;font-family:sans-serif;}
+.timeline{position:relative;margin:0 auto;padding:100px 0;width:200px;}
+.timeline::before{content:'';position:absolute;left:50%;top:0;bottom:0;width:4px;background:#ccc;transform:translateX(-50%);}
+.event{position:relative;margin:100px 0;padding-left:40px;}
+.event::before{content:'';position:absolute;left:-6px;top:0;width:16px;height:16px;border-radius:50%;background:#ccc;transition:background .3s;}
+.event.active::before{background:#4caf50;}

--- a/showcases/66-card-stack-depth-scroll/index.html
+++ b/showcases/66-card-stack-depth-scroll/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Card Stack Depth on Scroll</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div class="stack">
+    <div class="card">1</div>
+    <div class="card">2</div>
+    <div class="card">3</div>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/showcases/66-card-stack-depth-scroll/script.js
+++ b/showcases/66-card-stack-depth-scroll/script.js
@@ -1,0 +1,9 @@
+const cards=document.querySelectorAll('.card');
+function update(){
+  const s=window.scrollY;
+  cards.forEach((c,i)=>{
+    c.style.transform=`translateZ(${s*-0.5+i*-100}px)`;
+  });
+}
+window.addEventListener('scroll',update);
+update();

--- a/showcases/66-card-stack-depth-scroll/styles.css
+++ b/showcases/66-card-stack-depth-scroll/styles.css
@@ -1,0 +1,6 @@
+body{margin:0;height:200vh;display:flex;justify-content:center;align-items:center;perspective:800px;background:#eee;}
+.stack{position:relative;transform-style:preserve-3d;width:200px;height:300px;}
+.card{position:absolute;top:0;left:0;width:100%;height:100%;background:#fff;border-radius:8px;box-shadow:0 10px 20px rgba(0,0,0,0.1);display:flex;align-items:center;justify-content:center;font-size:2rem;}
+.card:nth-child(1){background:#ffccbc;}
+.card:nth-child(2){background:#ffe0b2;}
+.card:nth-child(3){background:#fff9c4;}

--- a/showcases/67-3d-coverflow-gallery/index.html
+++ b/showcases/67-3d-coverflow-gallery/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>3D Coverflow Gallery</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div class="coverflow">
+    <img src="https://picsum.photos/seed/1/300/200" alt="" />
+    <img src="https://picsum.photos/seed/2/300/200" alt="" />
+    <img src="https://picsum.photos/seed/3/300/200" alt="" />
+    <img src="https://picsum.photos/seed/4/300/200" alt="" />
+    <img src="https://picsum.photos/seed/5/300/200" alt="" />
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/showcases/67-3d-coverflow-gallery/script.js
+++ b/showcases/67-3d-coverflow-gallery/script.js
@@ -1,0 +1,12 @@
+const container=document.querySelector('.coverflow');
+function update(){
+  const center=container.scrollLeft+container.clientWidth/2;
+  document.querySelectorAll('.coverflow img').forEach(img=>{
+    const rect=img.getBoundingClientRect();
+    const imgCenter=rect.left+rect.width/2;
+    const diff=(imgCenter-container.clientWidth/2)/container.clientWidth;
+    img.style.transform=`rotateY(${diff*45}deg)`;
+  });
+}
+container.addEventListener('scroll',update);
+update();

--- a/showcases/67-3d-coverflow-gallery/styles.css
+++ b/showcases/67-3d-coverflow-gallery/styles.css
@@ -1,0 +1,3 @@
+body{margin:0;}
+.coverflow{display:flex;overflow-x:auto;height:100vh;align-items:center;scroll-snap-type:x mandatory;perspective:1000px;}
+.coverflow img{width:300px;height:200px;object-fit:cover;margin:0 20px;scroll-snap-align:center;transition:transform .3s;}

--- a/showcases/68-tilted-content-sections/index.html
+++ b/showcases/68-tilted-content-sections/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Tilted Content Sections</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <section class="tilt one"><div class="inner"><h1>Section One</h1></div></section>
+  <section class="tilt two"><div class="inner"><h1>Section Two</h1></div></section>
+</body>
+</html>

--- a/showcases/68-tilted-content-sections/styles.css
+++ b/showcases/68-tilted-content-sections/styles.css
@@ -1,0 +1,5 @@
+body{margin:0;font-family:sans-serif;}
+.tilt{height:100vh;display:flex;align-items:center;transform:skewY(-4deg);color:#fff;background-attachment:fixed;background-size:cover;}
+.tilt .inner{transform:skewY(4deg);margin:0 auto;font-size:3rem;}
+.one{background-image:url('https://picsum.photos/seed/t1/1200/800');}
+.two{background-image:url('https://picsum.photos/seed/t2/1200/800');}

--- a/showcases/69-sticky-image-gallery/index.html
+++ b/showcases/69-sticky-image-gallery/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Sticky Image Gallery</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+<div class="wrapper">
+  <div class="images"><img id="display" src="https://picsum.photos/seed/1/600/400" alt=""></div>
+  <div class="text">
+    <section data-img="https://picsum.photos/seed/1/600/400"><h2>One</h2></section>
+    <section data-img="https://picsum.photos/seed/2/600/400"><h2>Two</h2></section>
+    <section data-img="https://picsum.photos/seed/3/600/400"><h2>Three</h2></section>
+  </div>
+</div>
+<script src="script.js"></script>
+</body>
+</html>

--- a/showcases/69-sticky-image-gallery/script.js
+++ b/showcases/69-sticky-image-gallery/script.js
@@ -1,0 +1,5 @@
+const display=document.getElementById('display');
+const obs=new IntersectionObserver(entries=>{
+  entries.forEach(e=>{if(e.isIntersecting){display.src=e.target.dataset.img;}});
+},{threshold:0.5});
+document.querySelectorAll('.text section').forEach(s=>obs.observe(s));

--- a/showcases/69-sticky-image-gallery/styles.css
+++ b/showcases/69-sticky-image-gallery/styles.css
@@ -1,0 +1,6 @@
+body{margin:0;font-family:sans-serif;}
+.wrapper{display:flex;}
+.images{position:sticky;top:0;height:100vh;width:50%;display:flex;align-items:center;justify-content:center;background:#000;}
+.images img{max-width:100%;max-height:100%;}
+.text{width:50%;}
+.text section{height:100vh;display:flex;align-items:center;justify-content:center;font-size:3rem;}

--- a/showcases/70-scroll-triggered-counter/index.html
+++ b/showcases/70-scroll-triggered-counter/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Scroll-Triggered Counter</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div class="counter" data-target="1234">0</div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/showcases/70-scroll-triggered-counter/script.js
+++ b/showcases/70-scroll-triggered-counter/script.js
@@ -1,0 +1,16 @@
+const counter=document.querySelector('.counter');
+let started=false;
+function animate(){
+  const target=+counter.dataset.target;
+  let current=0;
+  const step=target/100;
+  const interval=setInterval(()=>{
+    current+=step;
+    if(current>=target){current=target;clearInterval(interval);}
+    counter.textContent=Math.floor(current);
+  },20);
+}
+const obs=new IntersectionObserver(entries=>{
+  entries.forEach(e=>{if(e.isIntersecting&&!started){started=true;animate();}});
+},{threshold:0.5});
+obs.observe(counter);

--- a/showcases/70-scroll-triggered-counter/styles.css
+++ b/showcases/70-scroll-triggered-counter/styles.css
@@ -1,0 +1,2 @@
+body{margin:0;height:200vh;display:flex;justify-content:center;align-items:center;font-size:4rem;font-family:monospace;}
+.counter{background:#111;color:#fff;padding:20px;border-radius:8px;}


### PR DESCRIPTION
## Summary
- add typewriter caret animation
- implement gradient text shine effect
- create wave section divider and diagonal panel reveal
- build timeline, card stack, coverflow, tilted sections
- add sticky gallery and scroll-triggered counter

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689979710b388333b569768d77579a80