### PR TITLE
feat: add showcases 71-80

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,6 +128,16 @@
         { title: 'Tilted Content Sections', path: 'showcases/68-tilted-content-sections/index.html' },
         { title: 'Sticky Image Gallery', path: 'showcases/69-sticky-image-gallery/index.html' },
         { title: 'Scroll-Triggered Counter', path: 'showcases/70-scroll-triggered-counter/index.html' },
+        { title: 'SVG Icon Micro-Interactions', path: 'showcases/71-svg-icon-micro-interactions/index.html' },
+        { title: 'Checkbox to Confetti', path: 'showcases/72-checkbox-to-confetti/index.html' },
+        { title: 'Switch Toggle with Spring', path: 'showcases/73-switch-toggle-spring/index.html' },
+        { title: 'Like Button Burst', path: 'showcases/74-like-button-burst/index.html' },
+        { title: 'Bookmark Ribbon Fold', path: 'showcases/75-bookmark-ribbon-fold/index.html' },
+        { title: 'Animated Avatars Group', path: 'showcases/76-animated-avatars-group/index.html' },
+        { title: 'Wave Loading Bars', path: 'showcases/77-wave-loading-bars/index.html' },
+        { title: 'Circular Menu Orbit', path: 'showcases/78-circular-menu-orbit/index.html' },
+        { title: 'SVG Path Scroll Indicator', path: 'showcases/79-svg-path-scroll-indicator/index.html' },
+        { title: 'Hover Reveal Mask Gallery', path: 'showcases/80-hover-reveal-mask-gallery/index.html' },
       ];
     const menu = document.getElementById('menu');
     const frame = document.getElementById('frame');

--- a/showcases/71-svg-icon-micro-interactions/index.html
+++ b/showcases/71-svg-icon-micro-interactions/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1.0">
+<title>SVG Icon Micro-Interactions</title>
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<svg id="icon" viewBox="0 0 100 100" class="icon">
+  <path fill="none" stroke="#e91e63" stroke-width="8" d="M20,50 L80,50">
+    <animate id="toTriangle" attributeName="d" to="M50,20 L80,80 L20,80 Z" dur="0.3s" fill="freeze" begin="icon.mouseover" />
+    <animate attributeName="d" to="M20,50 L80,50" dur="0.3s" fill="freeze" begin="icon.mouseout" />
+  </path>
+</svg>
+<script src="script.js"></script>
+</body>
+</html>

--- a/showcases/71-svg-icon-micro-interactions/script.js
+++ b/showcases/71-svg-icon-micro-interactions/script.js
@@ -1,0 +1,1 @@
+// no additional JS needed; svg SMIL handles morph

--- a/showcases/71-svg-icon-micro-interactions/styles.css
+++ b/showcases/71-svg-icon-micro-interactions/styles.css
@@ -1,0 +1,2 @@
+body{display:flex;align-items:center;justify-content:center;height:100vh;margin:0;background:#f0f0f0;}
+.icon{width:120px;height:120px;cursor:pointer;}

--- a/showcases/72-checkbox-to-confetti/index.html
+++ b/showcases/72-checkbox-to-confetti/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1.0">
+<title>Checkbox to Confetti</title>
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<label class="check-wrap">
+  <input type="checkbox" id="box">
+  <span class="check"></span>
+</label>
+<div id="confetti"></div>
+<script src="script.js"></script>
+</body>
+</html>

--- a/showcases/72-checkbox-to-confetti/script.js
+++ b/showcases/72-checkbox-to-confetti/script.js
@@ -1,0 +1,16 @@
+const box=document.getElementById('box');
+const container=document.getElementById('confetti');
+box.addEventListener('change',()=>{
+  if(box.checked){
+    for(let i=0;i<20;i++){
+      const div=document.createElement('div');
+      div.className='confetti';
+      div.style.setProperty('--c',`hsl(${Math.random()*360},80%,60%)`);
+      div.style.left=box.offsetLeft+30+Math.random()*20-10+'px';
+      div.style.top=box.offsetTop+30+'px';
+      div.style.setProperty('--tx',Math.random()*200-100+'px');
+      container.appendChild(div);
+      setTimeout(()=>div.remove(),1000);
+    }
+  }
+});

--- a/showcases/72-checkbox-to-confetti/styles.css
+++ b/showcases/72-checkbox-to-confetti/styles.css
@@ -1,0 +1,9 @@
+body{display:flex;align-items:center;justify-content:center;height:100vh;margin:0;background:#fafafa;}
+.check-wrap{position:relative;width:60px;height:60px;}
+.check-wrap input{opacity:0;width:0;height:0;}
+.check{position:absolute;top:0;left:0;width:100%;height:100%;border:4px solid #555;border-radius:8px;cursor:pointer;}
+.check::after{content:"";position:absolute;left:14px;top:6px;width:16px;height:32px;border:4px solid #4caf50;border-top:none;border-left:none;transform:rotate(45deg) scale(0);transition:transform .2s ease;}
+#box:checked + .check::after{transform:rotate(45deg) scale(1);}
+#confetti{position:fixed;top:0;left:0;pointer-events:none;width:100%;height:100%;overflow:hidden;}
+.confetti{position:absolute;width:8px;height:12px;background:var(--c);animation:fall 1s forwards ease-out;}
+@keyframes fall{to{transform:translate(var(--tx),600px) rotate(720deg);opacity:0;}}

--- a/showcases/73-switch-toggle-spring/index.html
+++ b/showcases/73-switch-toggle-spring/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1.0">
+<title>Switch Toggle with Spring</title>
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<label class="switch">
+  <input type="checkbox" id="toggle">
+  <span class="slider"></span>
+</label>
+<script src="script.js"></script>
+</body>
+</html>

--- a/showcases/73-switch-toggle-spring/script.js
+++ b/showcases/73-switch-toggle-spring/script.js
@@ -1,0 +1,1 @@
+// No JS needed for this demo

--- a/showcases/73-switch-toggle-spring/styles.css
+++ b/showcases/73-switch-toggle-spring/styles.css
@@ -1,0 +1,7 @@
+body{display:flex;align-items:center;justify-content:center;height:100vh;margin:0;background:#fdfdfd;}
+.switch{position:relative;width:80px;height:40px;}
+.switch input{opacity:0;width:0;height:0;}
+.slider{position:absolute;cursor:pointer;top:0;left:0;right:0;bottom:0;background:#ccc;border-radius:40px;transition:background .4s;}
+.slider::before{content:"";position:absolute;height:32px;width:32px;left:4px;top:4px;background:white;border-radius:50%;transition:transform .4s cubic-bezier(.68,-0.55,.27,1.55);}
+#toggle:checked + .slider{background:#4caf50;}
+#toggle:checked + .slider::before{transform:translateX(40px);}

--- a/showcases/74-like-button-burst/index.html
+++ b/showcases/74-like-button-burst/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1.0">
+<title>Like Button Burst</title>
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<button id="like" class="heart">❤</button>
+<div id="burst-container"></div>
+<script src="script.js"></script>
+</body>
+</html>

--- a/showcases/74-like-button-burst/script.js
+++ b/showcases/74-like-button-burst/script.js
@@ -1,0 +1,17 @@
+const btn=document.getElementById('like');
+const container=document.getElementById('burst-container');
+btn.addEventListener('click',()=>{
+  btn.classList.toggle('liked');
+  for(let i=0;i<8;i++){
+    const b=document.createElement('span');
+    b.className='burst';
+    const angle=Math.random()*Math.PI*2;
+    const dist=80;
+    b.style.setProperty('--x',Math.cos(angle)*dist+'px');
+    b.style.setProperty('--y',Math.sin(angle)*dist+'px');
+    b.style.left=btn.offsetLeft+30+'px';
+    b.style.top=btn.offsetTop+30+'px';
+    container.appendChild(b);
+    setTimeout(()=>b.remove(),600);
+  }
+});

--- a/showcases/74-like-button-burst/styles.css
+++ b/showcases/74-like-button-burst/styles.css
@@ -1,0 +1,6 @@
+body{display:flex;align-items:center;justify-content:center;height:100vh;margin:0;background:#fff;}
+.heart{font-size:60px;background:none;border:none;cursor:pointer;color:#aaa;transition:color .3s;position:relative;}
+.heart.liked{color:#e91e63;}
+#burst-container{position:absolute;top:0;left:0;width:100%;height:100%;pointer-events:none;overflow:hidden;}
+.burst{position:absolute;width:6px;height:6px;border-radius:50%;background:#e91e63;animation:explode .6s forwards;}
+@keyframes explode{to{transform:translate(var(--x),var(--y)) scale(0);opacity:0;}}

--- a/showcases/75-bookmark-ribbon-fold/index.html
+++ b/showcases/75-bookmark-ribbon-fold/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1.0">
+<title>Bookmark Ribbon Fold</title>
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<div class="card">
+  <div class="ribbon"></div>
+  <p>Hover to fold ribbon</p>
+</div>
+<script src="script.js"></script>
+</body>
+</html>

--- a/showcases/75-bookmark-ribbon-fold/script.js
+++ b/showcases/75-bookmark-ribbon-fold/script.js
@@ -1,0 +1,1 @@
+// No JS needed

--- a/showcases/75-bookmark-ribbon-fold/styles.css
+++ b/showcases/75-bookmark-ribbon-fold/styles.css
@@ -1,0 +1,4 @@
+body{display:flex;align-items:center;justify-content:center;height:100vh;margin:0;background:#f0f0f0;font-family:sans-serif;}
+.card{position:relative;width:200px;height:120px;background:white;box-shadow:0 2px 6px rgba(0,0,0,.1);display:flex;align-items:center;justify-content:center;}
+.ribbon{position:absolute;top:0;right:0;width:0;height:0;border-top:50px solid #ff5722;border-left:50px solid transparent;transform-origin:100% 0;transition:transform .4s;}
+.card:hover .ribbon{transform:rotateX(90deg);} 

--- a/showcases/76-animated-avatars-group/index.html
+++ b/showcases/76-animated-avatars-group/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1.0">
+<title>Animated Avatars Group</title>
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<div class="avatars">
+  <img src="https://picsum.photos/seed/a/80" alt="a">
+  <img src="https://picsum.photos/seed/b/80" alt="b">
+  <img src="https://picsum.photos/seed/c/80" alt="c">
+  <img src="https://picsum.photos/seed/d/80" alt="d">
+</div>
+<script src="script.js"></script>
+</body>
+</html>

--- a/showcases/76-animated-avatars-group/script.js
+++ b/showcases/76-animated-avatars-group/script.js
@@ -1,0 +1,1 @@
+// No JS needed

--- a/showcases/76-animated-avatars-group/styles.css
+++ b/showcases/76-animated-avatars-group/styles.css
@@ -1,0 +1,8 @@
+body{display:flex;align-items:center;justify-content:center;height:100vh;margin:0;background:#fff;}
+.avatars{display:flex;}
+.avatars img{width:60px;height:60px;border-radius:50%;border:2px solid #fff;margin-left:-15px;transition:transform .3s;box-shadow:0 2px 4px rgba(0,0,0,.2);}
+.avatars:hover img{transform:translateX(calc(var(--i)*20px));}
+.avatars img:nth-child(1){--i:0;}
+.avatars img:nth-child(2){--i:1;}
+.avatars img:nth-child(3){--i:2;}
+.avatars img:nth-child(4){--i:3;}

--- a/showcases/77-wave-loading-bars/index.html
+++ b/showcases/77-wave-loading-bars/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1.0">
+<title>Wave Loading Bars</title>
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<div class="bars">
+  <div></div><div></div><div></div><div></div><div></div>
+</div>
+<script src="script.js"></script>
+</body>
+</html>

--- a/showcases/77-wave-loading-bars/script.js
+++ b/showcases/77-wave-loading-bars/script.js
@@ -1,0 +1,1 @@
+// No JS needed

--- a/showcases/77-wave-loading-bars/styles.css
+++ b/showcases/77-wave-loading-bars/styles.css
@@ -1,0 +1,8 @@
+body{display:flex;align-items:center;justify-content:center;height:100vh;margin:0;background:#222;}
+.bars{display:flex;gap:4px;}
+.bars div{width:10px;height:40px;background:linear-gradient(180deg,#4caf50,#81c784);animation:wave 1s infinite ease-in-out;}
+.bars div:nth-child(2){animation-delay:.1s}
+.bars div:nth-child(3){animation-delay:.2s}
+.bars div:nth-child(4){animation-delay:.3s}
+.bars div:nth-child(5){animation-delay:.4s}
+@keyframes wave{0%,40%,100%{transform:scaleY(.4);}20%{transform:scaleY(1);}}

--- a/showcases/78-circular-menu-orbit/index.html
+++ b/showcases/78-circular-menu-orbit/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1.0">
+<title>Circular Menu Orbit</title>
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<div class="menu">
+  <button class="center" id="toggle">+</button>
+  <a class="item">A</a>
+  <a class="item">B</a>
+  <a class="item">C</a>
+  <a class="item">D</a>
+</div>
+<script src="script.js"></script>
+</body>
+</html>

--- a/showcases/78-circular-menu-orbit/script.js
+++ b/showcases/78-circular-menu-orbit/script.js
@@ -1,0 +1,3 @@
+const toggle=document.getElementById('toggle');
+const menu=document.querySelector('.menu');
+toggle.addEventListener('click',()=>menu.classList.toggle('open'));

--- a/showcases/78-circular-menu-orbit/styles.css
+++ b/showcases/78-circular-menu-orbit/styles.css
@@ -1,0 +1,9 @@
+body{display:flex;align-items:center;justify-content:center;height:100vh;margin:0;background:#222;color:#fff;font-family:sans-serif;}
+.menu{position:relative;width:120px;height:120px;}
+.center{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:50px;height:50px;border-radius:50%;border:none;background:#e91e63;color:#fff;font-size:24px;cursor:pointer;}
+.item{position:absolute;top:50%;left:50%;width:40px;height:40px;border-radius:50%;background:#03a9f4;display:flex;align-items:center;justify-content:center;transform:translate(-50%,-50%) scale(0);transition:transform .4s;}
+.menu.open .item{transform:translate(-50%,-50%) scale(1);}
+.menu.open .item:nth-of-type(2){transform:translate(-50%,-50%) translate(0,-70px) scale(1);}
+.menu.open .item:nth-of-type(3){transform:translate(-50%,-50%) translate(60px,0) scale(1);}
+.menu.open .item:nth-of-type(4){transform:translate(-50%,-50%) translate(0,70px) scale(1);}
+.menu.open .item:nth-of-type(5){transform:translate(-50%,-50%) translate(-60px,0) scale(1);}

--- a/showcases/79-svg-path-scroll-indicator/index.html
+++ b/showcases/79-svg-path-scroll-indicator/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1.0">
+<title>SVG Path Scroll Indicator</title>
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<svg id="progress" width="50" height="100%" style="position:fixed;top:0;left:0">
+  <path id="bar" d="M25 0 V1000" stroke="#2196f3" stroke-width="4" fill="none" />
+</svg>
+<div style="height:2000px"></div>
+<script src="script.js"></script>
+</body>
+</html>

--- a/showcases/79-svg-path-scroll-indicator/script.js
+++ b/showcases/79-svg-path-scroll-indicator/script.js
@@ -1,0 +1,9 @@
+const path=document.getElementById('bar');
+const length=path.getTotalLength();
+path.style.strokeDasharray=length;
+path.style.strokeDashoffset=length;
+window.addEventListener('scroll',()=>{
+  const max=document.body.scrollHeight - innerHeight;
+  const progress=scrollY/max;
+  path.style.strokeDashoffset=length*(1-progress);
+});

--- a/showcases/79-svg-path-scroll-indicator/styles.css
+++ b/showcases/79-svg-path-scroll-indicator/styles.css
@@ -1,0 +1,1 @@
+body{margin:0;}

--- a/showcases/80-hover-reveal-mask-gallery/index.html
+++ b/showcases/80-hover-reveal-mask-gallery/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1.0">
+<title>Hover Reveal Mask Gallery</title>
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<div class="gallery" id="gal">
+  <img src="https://picsum.photos/seed/1/300/200" alt="1">
+  <img src="https://picsum.photos/seed/2/300/200" alt="2">
+  <img src="https://picsum.photos/seed/3/300/200" alt="3">
+  <img src="https://picsum.photos/seed/4/300/200" alt="4">
+  <img src="https://picsum.photos/seed/5/300/200" alt="5">
+  <img src="https://picsum.photos/seed/6/300/200" alt="6">
+</div>
+<script src="script.js"></script>
+</body>
+</html>

--- a/showcases/80-hover-reveal-mask-gallery/script.js
+++ b/showcases/80-hover-reveal-mask-gallery/script.js
@@ -1,0 +1,8 @@
+const gal=document.getElementById('gal');
+gal.addEventListener('mousemove',e=>{
+  const rect=gal.getBoundingClientRect();
+  const x=e.clientX-rect.left;
+  const y=e.clientY-rect.top;
+  gal.style.setProperty('--x',x+'px');
+  gal.style.setProperty('--y',y+'px');
+});

--- a/showcases/80-hover-reveal-mask-gallery/styles.css
+++ b/showcases/80-hover-reveal-mask-gallery/styles.css
@@ -1,0 +1,4 @@
+body{margin:0;display:flex;align-items:center;justify-content:center;height:100vh;background:#000;}
+.gallery{position:relative;display:grid;grid-template-columns:repeat(3,100px);grid-gap:10px;}
+.gallery img{width:100px;height:100px;object-fit:cover;}
+.gallery::after{content:"";position:absolute;inset:0;background:rgba(0,0,0,.8);pointer-events:none;mask:radial-gradient(circle at var(--x,50%) var(--y,50%),transparent 80px,black 81px);}


### PR DESCRIPTION
## Summary
- add SVG path morph hover demo
- add checkbox confetti celebration
- add springy switch toggle and like button burst
- add ribbon fold, avatar fan-out, wave bars, circular menu, scroll indicator, and mask gallery

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68998fa781748333828e00e970fab230