### PR TITLE
Improve code viewer readability

### DIFF
--- a/index.html
+++ b/index.html
@@ -150,6 +150,9 @@
       margin: 0;
       padding: 16px;
       overflow: auto;
+      background: #1e1e1e;
+      color: #eaeaea;
+      font-family: "Courier New", Courier, monospace;
     }
     #code-viewer .code-tabs {
       display: flex;

--- a/index.html
+++ b/index.html
@@ -152,7 +152,7 @@
       overflow: auto;
       background: #1e1e1e;
       color: #eaeaea;
-      font-family: "Courier New", Courier, monospace;
+      font-family: 'SF Mono', 'Monaco', 'Inconsolata', 'Roboto Mono', 'Consolas', monospace;
     }
     #code-viewer .code-tabs {
       display: flex;


### PR DESCRIPTION
## Summary
- Adjust code preview styling for better contrast with dark background and light text

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899a175b3588333a170543ec1deb901